### PR TITLE
fix: fix providing the correct baseline path through method/service options

### DIFF
--- a/.changeset/witty-cats-invite.md
+++ b/.changeset/witty-cats-invite.md
@@ -1,0 +1,5 @@
+---
+"@wdio/visual-service": patch
+---
+
+fix default snapshot path to be overwritten through method/service options

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -1,5 +1,6 @@
 import logger from '@wdio/logger'
 import { expect } from '@wdio/globals'
+import { dirname, normalize, resolve } from 'node:path'
 import type { Capabilities, Frameworks } from '@wdio/types'
 import type { ClassOptions } from 'webdriver-image-comparison'
 import {
@@ -12,6 +13,7 @@ import {
     saveScreen,
     saveTabbablePage,
     checkTabbablePage,
+    FOLDERS,
 } from 'webdriver-image-comparison'
 import { determineNativeContext, getFolders, getInstanceData } from './utils.js'
 import {
@@ -72,7 +74,7 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     beforeTest(test: Frameworks.Test) {
-        this.#currentFilePath = test.file
+        this.#currentFilePath = resolve(dirname(test.file), FOLDERS.DEFAULT.BASE)
     }
 
     afterCommand (commandName:string, _args:string[], result:number|string, error:any) {
@@ -83,15 +85,19 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     #getBaselineFolder() {
+        const baselineFolder =(normalize(FOLDERS.DEFAULT.BASE) === this.folders.baselineFolder
+            ? this.#currentFilePath
+            : this.folders.baselineFolder) as string
+
         /**
          * support `resolveSnapshotPath` WebdriverIO option
          * @ref https://webdriver.io/docs/configuration#resolvesnapshotpath
          */
         if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFilePath) {
-            return this.#config.resolveSnapshotPath(this.#currentFilePath, '.png')
+            return this.#config.resolveSnapshotPath(baselineFolder, '.png')
         }
 
-        return this.#currentFilePath
+        return baselineFolder
     }
 
     async #extendMultiremoteBrowser (capabilities: Capabilities.MultiRemoteCapabilities) {

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -37,6 +37,7 @@ const pageCommands = {
 
 export default class WdioImageComparisonService extends BaseClass {
     #config: WebdriverIO.Config
+    #currentFile?: string
     #currentFilePath?: string
     private _browser?: WebdriverIO.Browser | WebdriverIO.MultiRemoteBrowser
     private _isNativeContext: boolean | undefined
@@ -74,6 +75,7 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     beforeTest(test: Frameworks.Test) {
+        this.#currentFile = test.file
         this.#currentFilePath = resolve(dirname(test.file), FOLDERS.DEFAULT.BASE)
     }
 
@@ -95,8 +97,8 @@ export default class WdioImageComparisonService extends BaseClass {
          * We only use this option if the baselineFolder is the default one, otherwise the
          * service option for setting the baselineFolder should be used
          */
-        if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFilePath && isDefaultBaselineFolder) {
-            return this.#config.resolveSnapshotPath(this.#currentFilePath, '.png')
+        if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFile && isDefaultBaselineFolder) {
+            return this.#config.resolveSnapshotPath(this.#currentFile, '.png')
         }
 
         return baselineFolder

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -94,7 +94,7 @@ export default class WdioImageComparisonService extends BaseClass {
          * @ref https://webdriver.io/docs/configuration#resolvesnapshotpath
          */
         if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFilePath) {
-            return this.#config.resolveSnapshotPath(baselineFolder, '.png')
+            return this.#config.resolveSnapshotPath(this.#currentFilePath, '.png')
         }
 
         return baselineFolder

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -85,15 +85,17 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     #getBaselineFolder() {
-        const baselineFolder =(normalize(FOLDERS.DEFAULT.BASE) === this.folders.baselineFolder
-            ? this.#currentFilePath
-            : this.folders.baselineFolder) as string
+        const isDefaultBaselineFolder = normalize(FOLDERS.DEFAULT.BASE) === this.folders.baselineFolder
+        const baselineFolder =(isDefaultBaselineFolder? this.#currentFilePath : this.folders.baselineFolder) as string
 
         /**
          * support `resolveSnapshotPath` WebdriverIO option
          * @ref https://webdriver.io/docs/configuration#resolvesnapshotpath
+         *
+         * We only use this option if the baselineFolder is the default one, otherwise the
+         * service option for setting the baselineFolder should be used
          */
-        if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFilePath) {
+        if (typeof this.#config.resolveSnapshotPath === 'function' && this.#currentFilePath && isDefaultBaselineFolder) {
             return this.#config.resolveSnapshotPath(this.#currentFilePath, '.png')
         }
 

--- a/packages/service/src/utils.ts
+++ b/packages/service/src/utils.ts
@@ -1,8 +1,6 @@
-import path from 'node:path'
-
 import type { Capabilities } from '@wdio/types'
 import type { AppiumCapabilities } from 'node_modules/@wdio/types/build/Capabilities.js'
-import { IOS_OFFSETS, FOLDERS } from 'webdriver-image-comparison'
+import { IOS_OFFSETS } from 'webdriver-image-comparison'
 import type {
     Folders,
     InstanceData,
@@ -32,21 +30,15 @@ type getFolderMethodOptions =
     | SaveElementMethodOptions
     | SaveFullPageMethodOptions
     | SaveScreenMethodOptions;
+
 export function getFolders(
     methodOptions: getFolderMethodOptions,
     folders: Folders,
-    currentTestPath?: string
+    currentTestPath: string
 ): Folders {
-    /**
-     * by default we storing the screenshots in the `__snapshots__` folder
-     * next to the test file, unless the user provides a custom folder
-     */
-    const baselineFolder = currentTestPath
-        ? path.resolve(path.dirname(currentTestPath), FOLDERS.DEFAULT.BASE)
-        : undefined
     return {
         actualFolder: methodOptions.actualFolder ?? folders.actualFolder,
-        baselineFolder: methodOptions.baselineFolder ?? baselineFolder ?? folders.baselineFolder,
+        baselineFolder: methodOptions.baselineFolder ?? currentTestPath,
         diffFolder: methodOptions.diffFolder ?? folders.diffFolder,
     }
 }
@@ -246,3 +238,4 @@ export function determineNativeContext(
 
     return false
 }
+

--- a/packages/service/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/service/tests/__snapshots__/utils.test.ts.snap
@@ -11,7 +11,7 @@ exports[`utils > getFolders > should be able to return the correct folders when 
 exports[`utils > getFolders > should be able to return the correct folders when no method options are provided 1`] = `
 {
   "actualFolder": "folderActual",
-  "baselineFolder": "folderBase",
+  "baselineFolder": "/current/test/path/",
   "diffFolder": "folderDiff",
 }
 `;

--- a/packages/service/tests/utils.test.ts
+++ b/packages/service/tests/utils.test.ts
@@ -11,7 +11,8 @@ describe('utils', () => {
                 diffFolder: 'folderDiff',
                 actualFolder: 'folderActual',
             }
-            expect(getFolders(methodOptions, folders)).toMatchSnapshot()
+            const currentTestPath = '/current/test/path/'
+            expect(getFolders(methodOptions, folders, currentTestPath)).toMatchSnapshot()
         })
 
         it('should be able to return the correct folders when method options are provided', () => {
@@ -25,22 +26,8 @@ describe('utils', () => {
                 diffFolder: 'folderDiff',
                 actualFolder: 'folderActual',
             }
-            expect(getFolders(methodOptions, folders)).toMatchSnapshot()
-        })
-
-        it('should be able to return the correct baseline folder if a currentTestPath is provided', () => {
-            const baselineFolder = '/foo/bar'
-            const methodOptions = {}
-            const folders = {
-                baselineFolder: 'folderBase',
-                diffFolder: 'folderDiff',
-                actualFolder: 'folderActual',
-            }
-            const currentTestPath = '/path/to/test.ts'
-            expect(getFolders(methodOptions, folders, currentTestPath).baselineFolder)
-                .toBe('/path/to/__snapshots__')
-            expect(getFolders({ baselineFolder }, folders, currentTestPath).baselineFolder)
-                .toBe(baselineFolder)
+            const currentTestPath = '/current/test/path/'
+            expect(getFolders(methodOptions, folders, currentTestPath)).toMatchSnapshot()
         })
     })
 


### PR DESCRIPTION
This PR fixes the default snapshot path which could not be overwritten by the method/service options