### PR TITLE
build: Migrate to Husky v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#!/bin/sh
-
 git diff-index --cached --name-only --diff-filter=d HEAD | grep -E ".*\\.[cm]?[jt]sx?$" | xargs -r node_modules/eslint/bin/eslint.js

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,1 @@
-#!/bin/sh
-
 pnpm test:lint

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test.saucelabs.desktop": "SAUCE_ENV=desktop wdio ./tests/configs/wdio.saucelabs.web.conf.ts",
     "test.saucelabs.emu.web": "SAUCE_ENV=emu wdio ./tests/configs/wdio.saucelabs.web.conf.ts",
     "test.saucelabs.sims.web": "SAUCE_ENV=sims wdio ./tests/configs/wdio.saucelabs.web.conf.ts",
-    "prepare": "husky install",
+    "prepare": "husky",
     "watch": "pnpm run -r --parallel watch"
   },
   "dependencies": {


### PR DESCRIPTION
### Proposed Changes

Husky was updated to v9 without following the [How to Migrate](https://github.com/typicode/husky/releases/tag/v9.0.1) docs. This is similar to [webdriverio-community/wdio-electron-service#447](https://github.com/webdriverio-community/wdio-electron-service/pull/447).

* Update the `"prepare"` npm script
* Remove the shebang from the Git hooks

