### PR TITLE
ci: Update lewagon/wait-on-check-action to fix update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch PR metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@v1.6.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,7 +27,7 @@ jobs:
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed Changes

* Bump lewagon/wait-on-check-action to 1.3.3 to unblock the Dependabot PRs.

    Here is an example from [webdriverio/selenium-standalone](https://github.com/webdriverio/selenium-standalone/actions/runs/7958535376/job/21723602654?pr=876):
    ```
    Installing Bundler
    /opt/hostedtoolcache/Ruby/2.7.4/x64/bin/gem install bundler -v ~> 2
    ERROR:  Error installing bundler:
        The last version of bundler (~> 2) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
        bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.4.191.
    ```
* Bump dependabot/fetch-metadata to 1.6.0