### PR TITLE
Replaced file to filename to match whats running on jasmine-core

### DIFF
--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -88,7 +88,7 @@ export default class WdioImageComparisonService extends BaseClass {
 
     beforeTest(test: Frameworks.Test) {
         this.#currentFile = test.file || test.filename
-        this.#currentFilePath = resolve(dirname(test.filename), FOLDERS.DEFAULT.BASE)
+        this.#currentFilePath = resolve(dirname(test.file || test.filename), FOLDERS.DEFAULT.BASE)
     }
 
     afterCommand (commandName:string, _args:string[], result:number|string, error:any) {

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -87,8 +87,8 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     beforeTest(test: Frameworks.Test) {
-        this.#currentFile = test.file
-        this.#currentFilePath = resolve(dirname(test.file), FOLDERS.DEFAULT.BASE)
+        this.#currentFile = test.filename
+        this.#currentFilePath = resolve(dirname(test.filename), FOLDERS.DEFAULT.BASE)
     }
 
     afterCommand (commandName:string, _args:string[], result:number|string, error:any) {

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -87,7 +87,7 @@ export default class WdioImageComparisonService extends BaseClass {
     }
 
     beforeTest(test: Frameworks.Test) {
-        this.#currentFile = test.filename
+        this.#currentFile = test.file || test.filename
         this.#currentFilePath = resolve(dirname(test.filename), FOLDERS.DEFAULT.BASE)
     }
 


### PR DESCRIPTION
 throwing a type exception in node_modules@wdio\visual-service\dist\service.js file in beforeTest hook as it is expecting "filename" not just "file" - the property is from jasmine-core
"* https://github.com/Property {String} filename - The name of the file the spec was defined in."