### PR TITLE
fix(webdriver-image-comparison): export WicElement

### DIFF
--- a/.changeset/itchy-starfishes-tie.md
+++ b/.changeset/itchy-starfishes-tie.md
@@ -1,0 +1,6 @@
+---
+"webdriver-image-comparison": patch
+"@wdio/visual-service": patch
+---
+
+fix(webdriver-image-comparison): export WicElement

--- a/packages/visual-service/src/index.ts
+++ b/packages/visual-service/src/index.ts
@@ -1,4 +1,4 @@
-import type { WicElement } from 'webdriver-image-comparison/dist/commands/element.interfaces.js'
+import type { WicElement } from 'webdriver-image-comparison'
 import WdioImageComparisonService from './service.js'
 import VisualLauncher from './storybook/launcher.js'
 import type {

--- a/packages/webdriver-image-comparison/src/index.ts
+++ b/packages/webdriver-image-comparison/src/index.ts
@@ -17,6 +17,7 @@ export type {
     SaveScreenMethodOptions,
 } from './commands/screen.interfaces.js'
 export type {
+    WicElement,
     CheckElementMethodOptions,
     SaveElementMethodOptions,
 } from './commands/element.interfaces.js'


### PR DESCRIPTION
Just making the type import a bit cleaner by exporting the `WicElement` from the package.