### PR TITLE
fix click duration for 0ms

### DIFF
--- a/.changeset/large-clouds-confess.md
+++ b/.changeset/large-clouds-confess.md
@@ -1,0 +1,5 @@
+---
+"@wdio/ocr-service": minor
+---
+
+fix click duration for 0ms

--- a/packages/ocr-service/src/commands/ocrClickOnText.ts
+++ b/packages/ocr-service/src/commands/ocrClickOnText.ts
@@ -20,7 +20,7 @@ export default async function ocrClickOnText(options: OcrClickOnTextOptions): Pr
     await drawTarget({ filePath: element.filePath, targetX: x, targetY: y })
 
     const actionType = browser.isMobile ? 'touch' : 'mouse'
-    const clickDuration = options.clickDuration ? options.clickDuration : 500
+    const clickDuration = options.clickDuration ?? 500
 
     await browser
         .action('pointer', {


### PR DESCRIPTION
Fix the click duration if 0 is asked. For example, the default duration (500ms) was applied in this case: 

```
await browser.ocrClickOnText({
    text: "WebdriverIO",
    clickDuration: 0, // This is 0 seconds
}

```
