### PR TITLE
Ws/visual reporter fix cli paths

### DIFF
--- a/.changeset/thick-llamas-repair.md
+++ b/.changeset/thick-llamas-repair.md
@@ -1,0 +1,5 @@
+---
+"@wdio/visual-reporter": patch
+---
+
+fix paths for cli

--- a/packages/visual-reporter/scripts/cli.ts
+++ b/packages/visual-reporter/scripts/cli.ts
@@ -14,8 +14,8 @@ import { copyDirectory } from './utils/fileHandling.js'
 async function main() {
     //
     // Set some initial variables
-    let filePath = getArgValue('--jsonOutput')
-    let reportPath = getArgValue('--reportFolder')
+    const filePath = getArgValue('--jsonOutput') ? resolve(process.cwd(), getArgValue('--jsonOutput')) : undefined
+    const reportPath = getArgValue('--reportFolder') ? resolve(process.cwd(), getArgValue('--reportFolder')) : undefined
     const logLevel = getArgValue('--logLevel')
     const __filename = fileURLToPath(import.meta.url)
     const __dirname = dirname(__filename)


### PR DESCRIPTION
The PR fixes the issue that the CLI can now only accept absolute paths instead of relative paths