### PR TITLE
chore: remove node-fetch completely

### DIFF
--- a/.changeset/happy-laws-brake.md
+++ b/.changeset/happy-laws-brake.md
@@ -1,0 +1,5 @@
+---
+"@wdio/visual-service": patch
+---
+
+Removed unused `node-fetch` dependency

--- a/packages/visual-service/package.json
+++ b/packages/visual-service/package.json
@@ -29,7 +29,6 @@
     "@wdio/globals": "^9.9.1",
     "@wdio/logger": "^9.4.4",
     "@wdio/types": "^9.9.0",
-    "node-fetch": "^3.3.2",
     "webdriver-image-comparison": "^7.3.2"
   },
   "devDependencies": {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,9 +266,6 @@ importers:
       '@wdio/types':
         specifier: ^9.9.0
         version: 9.9.0
-      node-fetch:
-        specifier: ^3.3.2
-        version: 3.3.2
       webdriver-image-comparison:
         specifier: ^7.3.2
         version: 7.3.2


### PR DESCRIPTION
In #766 `node-fetch` was removed but forgotten from the dependencies. This removes it completely as it's unused.