### PR TITLE
chore: bump vitest and add vitest ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.vitest-ui
 
 # Dependency directories
 node_modules/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "run-s test:*",
     "test:lint": "rimraf .eslintcache && eslint packages tests",
     "test:unit": "vitest --coverage --run",
+    "test:unit:ui": "vitest --coverage --ui",
     "test:unit:watch": "vitest --coverage --watch",
     "test.local.init": "rimraf localBaseline && wdio ./tests/configs/wdio.local.init.conf.ts",
     "test.local.desktop": "wdio tests/configs/wdio.local.desktop.conf.ts",
@@ -50,22 +51,23 @@
     "watch": "pnpm run -r --parallel watch"
   },
   "dependencies": {
-    "@wdio/visual-service": "workspace:^",
     "@wdio/ocr-service": "workspace:^",
+    "@wdio/visual-service": "workspace:^",
     "webdriver-image-comparison": "workspace:^"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.12",
     "@tsconfig/node20": "^20.1.4",
     "@types/eslint": "^9.6.1",
-    "@types/jsdom": "~21.1.7",
     "@types/inquirer": "^9.0.7",
+    "@types/jsdom": "~21.1.7",
     "@types/node": "^22",
     "@types/xml2js": "~0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.24.0",
     "@typescript-eslint/utils": "^8.24.0",
-    "@vitest/coverage-v8": "^2.1.9",
+    "@vitest/coverage-v8": "^3.0.8",
+    "@vitest/ui": "^3.0.8",
     "@wdio/appium-service": "^9.9.1",
     "@wdio/cli": "^9.9.1",
     "@wdio/globals": "^9.9.1",
@@ -88,8 +90,8 @@
     "saucelabs": "^8.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
-    "vitest": "^2.1.9",
-    "webdriverio": "^9.9.1",
-    "wdio-lambdatest-service": "^4.0.0"
+    "vitest": "^3.0.8",
+    "wdio-lambdatest-service": "^4.0.0",
+    "webdriverio": "^9.9.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,11 @@ importers:
         specifier: ^8.24.0
         version: 8.24.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
       '@vitest/coverage-v8':
-        specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.4)(jsdom@25.0.1))
+        specifier: ^3.0.8
+        version: 3.0.8(vitest@3.0.8)
+      '@vitest/ui':
+        specifier: ^3.0.8
+        version: 3.0.8(vitest@3.0.8)
       '@wdio/appium-service':
         specifier: ^9.9.1
         version: 9.9.1
@@ -118,8 +121,8 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.13.4)(jsdom@25.0.1)
+        specifier: ^3.0.8
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@3.0.8)(jsdom@25.0.1)
       wdio-lambdatest-service:
         specifier: ^4.0.0
         version: 4.0.0(@wdio/cli@9.9.1)(@wdio/types@9.9.0)(webdriverio@9.9.1)
@@ -447,8 +450,9 @@ packages:
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
-  '@bcoe/v8-coverage@0.2.3':
-    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@changesets/apply-release-plan@7.0.8':
     resolution: {integrity: sha512-qjMUj4DYQ1Z6qHawsn7S71SujrExJ+nceyKKyI9iB+M5p9lCL55afuEd6uLBPRpLGWQwkwvWegDHtwHJb1UjpA==}
@@ -2073,23 +2077,23 @@ packages:
   '@vanilla-extract/private@1.0.6':
     resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
 
-  '@vitest/coverage-v8@2.1.9':
-    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+  '@vitest/coverage-v8@3.0.8':
+    resolution: {integrity: sha512-y7SAKsQirsEJ2F8bulBck4DoluhI2EEgTimHd6EEUgJBGKy9tC25cpywh1MH4FvDGoG2Unt7+asVd1kj4qOSAw==}
     peerDependencies:
-      '@vitest/browser': 2.1.9
-      vitest: 2.1.9
+      '@vitest/browser': 3.0.8
+      vitest: 3.0.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+  '@vitest/expect@3.0.8':
+    resolution: {integrity: sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==}
 
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+  '@vitest/mocker@3.0.8':
+    resolution: {integrity: sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2099,17 +2103,28 @@ packages:
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+  '@vitest/pretty-format@3.0.8':
+    resolution: {integrity: sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==}
+
+  '@vitest/runner@3.0.8':
+    resolution: {integrity: sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+  '@vitest/snapshot@3.0.8':
+    resolution: {integrity: sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==}
 
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  '@vitest/spy@3.0.8':
+    resolution: {integrity: sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==}
+
+  '@vitest/ui@3.0.8':
+    resolution: {integrity: sha512-MfTjaLU+Gw/lYorgwFZ06Cym+Mj9hPfZh/Q91d4JxyAHiicAakPTvS7zYCSHF+5cErwu2PVBe1alSjuh6L/UiA==}
+    peerDependencies:
+      vitest: 3.0.8
+
+  '@vitest/utils@3.0.8':
+    resolution: {integrity: sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==}
 
   '@wdio/appium-service@9.9.1':
     resolution: {integrity: sha512-GpJjRoPdaEu5d0MAglBAcc+9eR4hg3NugWDjJ6+z/vc5idwBRM/im1dfJSkcH5jqWFPu/meGdeHtTO49i2K3Eg==}
@@ -3539,6 +3554,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -3591,6 +3609,9 @@ packages:
 
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   flushwritable@1.0.0:
     resolution: {integrity: sha512-3VELfuWCLVzt5d2Gblk8qcqFro6nuwvxwMzHaENVDHI7rxcBRtMCwTk/E9FXcgh+82DSpavPNDueA9+RxXJoFg==}
@@ -6078,6 +6099,10 @@ packages:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
 
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+    engines: {node: '>=18'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -6409,12 +6434,20 @@ packages:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -6764,9 +6797,9 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.0.8:
+    resolution: {integrity: sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-tsconfig-paths@5.1.4:
@@ -6808,19 +6841,22 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.0.8:
+    resolution: {integrity: sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.8
+      '@vitest/ui': 3.0.8
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -7329,7 +7365,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@bcoe/v8-coverage@0.2.3': {}
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@changesets/apply-release-plan@7.0.8':
     dependencies:
@@ -9122,10 +9158,10 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.13.4)(jsdom@25.0.1))':
+  '@vitest/coverage-v8@3.0.8(vitest@3.0.8)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
+      '@bcoe/v8-coverage': 1.0.2
       debug: 4.4.0(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -9135,21 +9171,21 @@ snapshots:
       magicast: 0.3.5
       std-env: 3.8.0
       test-exclude: 7.0.1
-      tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.13.4)(jsdom@25.0.1)
+      tinyrainbow: 2.0.0
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@3.0.8)(jsdom@25.0.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
+  '@vitest/expect@3.0.8':
     dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/spy': 3.0.8
+      '@vitest/utils': 3.0.8
       chai: 5.2.0
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@22.13.4))':
+  '@vitest/mocker@3.0.8(vite@5.4.14(@types/node@22.13.4))':
     dependencies:
-      '@vitest/spy': 2.1.9
+      '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
@@ -9159,10 +9195,14 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.9':
+  '@vitest/pretty-format@3.0.8':
     dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.0.8':
+    dependencies:
+      '@vitest/utils': 3.0.8
+      pathe: 2.0.3
 
   '@vitest/snapshot@2.1.9':
     dependencies:
@@ -9170,15 +9210,32 @@ snapshots:
       magic-string: 0.30.17
       pathe: 1.1.2
 
-  '@vitest/spy@2.1.9':
+  '@vitest/snapshot@3.0.8':
+    dependencies:
+      '@vitest/pretty-format': 3.0.8
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.0.8':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@2.1.9':
+  '@vitest/ui@3.0.8(vitest@3.0.8)':
     dependencies:
-      '@vitest/pretty-format': 2.1.9
+      '@vitest/utils': 3.0.8
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.12
+      tinyrainbow: 2.0.0
+      vitest: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@3.0.8)(jsdom@25.0.1)
+
+  '@vitest/utils@3.0.8':
+    dependencies:
+      '@vitest/pretty-format': 3.0.8
       loupe: 3.1.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   '@wdio/appium-service@9.9.1':
     dependencies:
@@ -11069,6 +11126,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fflate@0.8.2: {}
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -11130,6 +11189,8 @@ snapshots:
   flat@5.0.2: {}
 
   flatted@3.3.2: {}
+
+  flatted@3.3.3: {}
 
   flushwritable@1.0.0: {}
 
@@ -14041,6 +14102,12 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  sirv@3.0.1:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.0
+      totalist: 3.0.1
+
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -14434,9 +14501,16 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
+
+  tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
 
@@ -14793,12 +14867,12 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@22.13.4):
+  vite-node@3.0.8(@types/node@22.13.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
-      pathe: 1.1.2
+      pathe: 2.0.3
       vite: 5.4.14(@types/node@22.13.4)
     transitivePeerDependencies:
       - '@types/node'
@@ -14831,30 +14905,32 @@ snapshots:
       '@types/node': 22.13.4
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.13.4)(jsdom@25.0.1):
+  vitest@3.0.8(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@3.0.8)(jsdom@25.0.1):
     dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@22.13.4))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
+      '@vitest/expect': 3.0.8
+      '@vitest/mocker': 3.0.8(vite@5.4.14(@types/node@22.13.4))
+      '@vitest/pretty-format': 3.0.8
+      '@vitest/runner': 3.0.8
+      '@vitest/snapshot': 3.0.8
+      '@vitest/spy': 3.0.8
+      '@vitest/utils': 3.0.8
       chai: 5.2.0
       debug: 4.4.0(supports-color@8.1.1)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 1.1.2
+      pathe: 2.0.3
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinypool: 1.0.2
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
       vite: 5.4.14(@types/node@22.13.4)
-      vite-node: 2.1.9(@types/node@22.13.4)
+      vite-node: 3.0.8(@types/node@22.13.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 22.13.4
+      '@vitest/ui': 3.0.8(vitest@3.0.8)
       jsdom: 25.0.1
     transitivePeerDependencies:
       - less

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, coverageConfigDefaults, defaultExclude } from 'vitest/config'
 
 export default defineConfig({
     test: {
         include: ['./packages/**/(tests|src)/**/*.test.ts'],
+        reporters: ['default', ['html', { outputFile: '.vitest-ui/index.html' }]],
         coverage: {
             thresholds: {
                 lines: 50,
@@ -11,30 +12,19 @@ export default defineConfig({
                 branches: 50
             },
             exclude: [
-                'packages/service/src/types.ts',
-                'packages/visual-reporter/',
-                'packages/visual-remix-reporter/',
-                '.eslintrc.cjs',
-                'tests/**',
+                ...coverageConfigDefaults.exclude,
+                // Types
+                '**/types.ts',
                 '**/*.interfaces.ts',
-                '**/storybookTypes.ts',
-                '**/apps/**',
-                '**/dist/**',
+                // Ignored folder
                 '**/resemble/**',
-                'eslint.config.cjs',
-                'vitest.config.ts',
-                '.tmp/**',
+                '**/dist/**',
+                // Others
+                'packages/visual-reporter/', // Need to improve visual reporter tests
             ]
         },
-        /**
-         * not to ESM ported packages
-         */
-        exclude: [
-            'dist',
-            '.idea',
-            '.git',
-            '.cache',
-            '**/node_modules/**',
-        ]
+        exclude: {
+            ...defaultExclude
+        }
     }
 })


### PR DESCRIPTION
### Description
While working on another features, I noticed it was quite hard to see the errors with the default reporter for Vitest.
This PR adds VitestUI and improves the Vitest config.

### Changes
- Bump Vitest packages to latest version (I followed the [migration guide](https://vitest.dev/guide/migration.html#vitest-3))
- Add VitestUI with a `test:unit:ui` command
- Cleaned up the current Vitest config
  - Some old leftovers
  - Leverage Vitest default configs
- Unrelated changes to `package.json` - pnpm automatically fixed the sorting on the packages

### Useful information
<details>
<summary>Current config (vitest v2) output</summary>

```
> vitest --coverage --run


 RUN  v2.1.9
      Coverage enabled with v8

 ✓ packages/ocr-service/tests/utils/imageProcessing.test.ts (9 tests) 11ms
 ✓ packages/ocr-service/tests/commands/tesseract.test.ts (24 tests) 13ms
 ✓ packages/ocr-service/tests/service.test.ts (6 tests) 5ms
 ✓ packages/visual-service/tests/storybook/utils.test.ts (64 tests) 42ms
 ✓ packages/webdriver-image-comparison/src/methods/rectangles.test.ts (14 tests) 9ms
 ✓ packages/webdriver-image-comparison/src/helpers/utils.test.ts (46 tests) 14ms
 ✓ packages/webdriver-image-comparison/src/methods/screenshots.test.ts (9 tests) 53ms
 ✓ packages/ocr-service/tests/commands/ocrClickOnText.test.ts (6 tests) 14ms
 ✓ packages/webdriver-image-comparison/src/methods/instanceData.test.ts (4 tests) 5ms
 ✓ packages/ocr-service/tests/utils/ocrGetData.test.ts (5 tests) 7ms
 ✓ packages/visual-service/tests/utils.test.ts (51 tests) 12ms
 ✓ packages/webdriver-image-comparison/src/helpers/options.test.ts (6 tests) 4ms
 ✓ packages/visual-service/tests/reporter.test.ts (7 tests) 14ms
 ✓ packages/ocr-service/tests/utils/fuzzySearch.test.ts (4 tests) 3ms
 ✓ packages/ocr-service/tests/utils/index.test.ts (10 tests) 5ms
 ✓ packages/ocr-service/tests/commands/orcGetElementPositionByText.test.ts (3 tests) 8ms
 ✓ packages/ocr-service/tests/commands/ocrSetValue.test.ts (3 tests) 5ms
 ✓ packages/visual-service/tests/matcher.test.ts (9 tests) 6ms
 ✓ packages/visual-service/tests/service.test.ts (7 tests) 8ms
 ✓ packages/visual-service/tests/storybook/launcher.test.ts (8 tests) 14ms
 ✓ packages/ocr-service/tests/utils/ocrGetTextPositions.test.ts (2 tests) 4ms
 ✓ packages/ocr-service/tests/commands/ocrWaitForTextDisplayed.test.ts (1 test) 6ms
 ✓ packages/webdriver-image-comparison/src/helpers/afterScreenshot.test.ts (1 test) 4ms
stdout | packages/webdriver-image-comparison/src/base.test.ts > BaseClass > clears runtime folders if clearRuntimeFolder is true
2025-03-16T13:31:41.775Z INFO @wdio/visual-service:webdriver-image-comparison: [33m
##############################
!!CLEARING!!
##############################[0m

 ✓ packages/webdriver-image-comparison/src/base.test.ts (5 tests) 6ms
 ✓ packages/ocr-service/tests/commands/ocrKeys.test.ts (3 tests) 6ms
 ✓ packages/ocr-service/tests/commands/ocrGetText.test.ts (1 test) 3ms
 ✓ packages/webdriver-image-comparison/src/helpers/beforeScreenshot.test.ts (2 tests) 505ms
   ✓ beforeScreenshot > should be able to return the enriched instance data with `addShadowPadding: true` 502ms
 ✓ packages/visual-service/tests/service.expect.test.ts (1 test) 2ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/setCustomCss.test.ts (5 tests) 14ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/hideRemoveElements.test.ts (8 tests) 28ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getIosStatusAddressToolBarOffsets.test.ts (12 tests) 5ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getAndroidStatusAddressToolBarHeight.test.ts (6 tests) 4ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopScreenNativeMobile.test.ts (3 tests) 13ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/removeElementFromDom.test.ts (4 tests) 18ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getDocumentScrollHeight.test.ts (3 tests) 14ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getScreenDimensions.test.ts (3 tests) 4ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/toggleTextTransparency.test.ts (2 tests) 21ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopWindow.test.ts (1 test) 10ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/hideScrollbars.test.ts (1 test) 3ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopDom.test.ts (1 test) 9ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/waitForFonts.test.ts (2 tests) 1013ms
   ✓ waitForFontsLoaded > should resolve if fonts load within 11 seconds 1006ms

 Test Files  41 passed (41)
      Tests  362 passed (362)
   Start at  13:31:40
   Duration  4.38s (transform 1.35s, setup 0ms, collect 5.29s, tests 1.95s, environment 6.88s, prepare 3.68s)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   76.29 |    93.55 |   80.55 |   76.29 |                   
 __mocks__/@wdio   |     100 |      100 |     100 |     100 |                   
  logger.ts        |     100 |      100 |     100 |     100 |                   
 ...cr-service/src |   31.96 |    88.88 |   77.77 |   31.96 |                   
  cli.ts           |       0 |        0 |       0 |       0 | 1-175             
  index.ts         |       0 |        0 |       0 |       0 | 1-55              
  service.ts       |   81.39 |      100 |     100 |   81.39 | 74-93             
  types.ts         |       0 |        0 |       0 |       0 |                   
 ...e/src/commands |     100 |      100 |     100 |     100 |                   
  ...lickOnText.ts |     100 |      100 |     100 |     100 |                   
  ...tionByText.ts |     100 |      100 |     100 |     100 |                   
  ocrGetText.ts    |     100 |      100 |     100 |     100 |                   
  ocrSetValue.ts   |     100 |      100 |     100 |     100 |                   
  ...tDisplayed.ts |     100 |      100 |     100 |     100 |                   
 ...vice/src/utils |   99.58 |    96.55 |     100 |   99.58 |                   
  constants.ts     |     100 |      100 |     100 |     100 |                   
  fuzzySearch.ts   |     100 |      100 |     100 |     100 |                   
  getData.ts       |    97.1 |       80 |     100 |    97.1 | 28-29             
  ...tPositions.ts |     100 |      100 |     100 |     100 |                   
  ...Processing.ts |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
  sendKeys.ts      |     100 |      100 |     100 |     100 |                   
  tesseract.ts     |     100 |      100 |     100 |     100 |                   
 ...-service/tests |     100 |      100 |     100 |     100 |                   
  service.test.ts  |     100 |      100 |     100 |     100 |                   
 ...tests/commands |    99.3 |    96.29 |     100 |    99.3 |                   
  ...nText.test.ts |     100 |      100 |     100 |     100 |                   
  ...tText.test.ts |     100 |      100 |     100 |     100 |                   
  ocrKeys.test.ts  |     100 |      100 |     100 |     100 |                   
  ...Value.test.ts |   96.36 |     87.5 |     100 |   96.36 | 90-91             
  ...layed.test.ts |     100 |      100 |     100 |     100 |                   
  ...yText.test.ts |     100 |      100 |     100 |     100 |                   
  ...eract.test.ts |   99.22 |       96 |     100 |   99.22 | 57-58,201         
 ...ce/tests/utils |     100 |      100 |     100 |     100 |                   
  ...earch.test.ts |     100 |      100 |     100 |     100 |                   
  ...ssing.test.ts |     100 |      100 |     100 |     100 |                   
  index.test.ts    |     100 |      100 |     100 |     100 |                   
  ...tData.test.ts |     100 |      100 |     100 |     100 |                   
  ...tions.test.ts |     100 |      100 |     100 |     100 |                   
 ...al-service/src |   70.12 |    93.78 |   89.79 |   70.12 |                   
  constants.ts     |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
  matcher.ts       |   93.54 |    81.81 |     100 |   93.54 | 15,50-53,106-108  
  reporter.ts      |     100 |      100 |     100 |     100 |                   
  service.ts       |   43.24 |    92.85 |      75 |   43.24 | ...05-412,418-466 
  types.ts         |       0 |        0 |       0 |       0 |                   
  utils.ts         |   81.39 |     97.7 |   91.66 |   81.39 | ...46-347,353-402 
 .../src/storybook |   94.49 |    98.58 |     100 |   94.49 |                   
  Types.ts         |       0 |        0 |       0 |       0 |                   
  ...escriptors.ts |     100 |      100 |     100 |     100 |                   
  launcher.ts      |    94.8 |    97.14 |     100 |    94.8 | 118-121           
  utils.ts         |   91.24 |    99.04 |     100 |   91.24 | 234-273           
 ...-service/tests |   99.91 |    99.11 |     100 |   99.91 |                   
  matcher.test.ts  |     100 |      100 |     100 |     100 |                   
  reporter.test.ts |   98.87 |       95 |     100 |   98.87 | 87                
  ...s.mockdata.ts |     100 |      100 |     100 |     100 |                   
  ...xpect.test.ts |     100 |      100 |     100 |     100 |                   
  service.test.ts  |     100 |      100 |     100 |     100 |                   
  utils.test.ts    |     100 |      100 |     100 |     100 |                   
 ...ests/storybook |   97.64 |    91.42 |     100 |   97.64 |                   
  launcher.test.ts |   89.74 |       60 |     100 |   89.74 | ...90-191,206-207 
  utils.test.ts    |   99.53 |    98.26 |     100 |   99.53 | 477,834-835       
 ...comparison/src |   98.46 |    94.44 |      80 |   98.46 |                   
  base.test.ts     |     100 |      100 |     100 |     100 |                   
  base.ts          |     100 |      100 |     100 |     100 |                   
  index.ts         |       0 |        0 |       0 |       0 | 1                 
 ...entSideScripts |   80.34 |    98.19 |   95.45 |   80.34 |                   
  ...leOnCanvas.ts |       0 |      100 |     100 |       0 | 9-316             
  ...eight.test.ts |     100 |      100 |     100 |     100 |                   
  ...BarOffsets.ts |     100 |      100 |     100 |     100 |                   
  ...eight.test.ts |     100 |      100 |     100 |     100 |                   
  ...rollHeight.ts |      80 |    83.33 |     100 |      80 | 44-49             
  ...opDom.test.ts |     100 |      100 |     100 |     100 |                   
  ...tionTopDom.ts |     100 |      100 |     100 |     100 |                   
  ...obile.test.ts |     100 |      100 |     100 |     100 |                   
  ...tiveMobile.ts |     100 |      100 |     100 |     100 |                   
  ...indow.test.ts |     100 |      100 |     100 |     100 |                   
  ...nTopWindow.ts |     100 |      100 |     100 |     100 |                   
  ...fsets.test.ts |     100 |      100 |     100 |     100 |                   
  ...BarOffsets.ts |     100 |      100 |     100 |     100 |                   
  ...sions.test.ts |     100 |      100 |     100 |     100 |                   
  ...Dimensions.ts |     100 |      100 |     100 |     100 |                   
  ...ments.test.ts |     100 |      100 |     100 |     100 |                   
  ...veElements.ts |     100 |      100 |     100 |     100 |                   
  ...lbars.test.ts |     100 |      100 |     100 |     100 |                   
  ...Scrollbars.ts |   83.33 |       75 |     100 |   83.33 | 13                
  ...omDom.test.ts |     100 |    83.33 |     100 |     100 | 11                
  ...entFromDom.ts |     100 |      100 |     100 |     100 |                   
  ...ntIntoView.ts |       0 |      100 |     100 |       0 | 4-35              
  ...ToPosition.ts |       0 |      100 |       0 |       0 | 5-28              
  ...omCss.test.ts |     100 |      100 |     100 |     100 |                   
  setCustomCss.ts  |     100 |      100 |     100 |     100 |                   
  ...rency.test.ts |     100 |      100 |     100 |     100 |                   
  ...ansparency.ts |    92.3 |      100 |     100 |    92.3 | 15                
  ...Fonts.test.ts |     100 |      100 |     100 |     100 |                   
  waitForFonts.ts  |     100 |      100 |     100 |     100 |                   
 ...n/src/commands |       0 |        0 |       0 |       0 |                   
  ...AppElement.ts |       0 |        0 |       0 |       0 | 1-79              
  ...kAppScreen.ts |       0 |        0 |       0 |       0 | 1-105             
  checkElement.ts  |       0 |        0 |       0 |       0 | 1-24              
  ...PageScreen.ts |       0 |        0 |       0 |       0 | 1-85              
  checkScreen.ts   |       0 |        0 |       0 |       0 | 1-23              
  ...bbablePage.ts |       0 |        0 |       0 |       0 | 1-46              
  ...WebElement.ts |       0 |        0 |       0 |       0 | 1-86              
  ...kWebScreen.ts |       0 |        0 |       0 |       0 | 1-78              
  ...AppElement.ts |       0 |        0 |       0 |       0 | 1-89              
  saveAppScreen.ts |       0 |        0 |       0 |       0 | 1-95              
  saveElement.ts   |       0 |        0 |       0 |       0 | 1-23              
  ...PageScreen.ts |       0 |        0 |       0 |       0 | 1-147             
  saveScreen.ts    |       0 |        0 |       0 |       0 | 1-22              
  ...bbablePage.ts |       0 |        0 |       0 |       0 | 1-36              
  ...WebElement.ts |       0 |        0 |       0 |       0 | 1-177             
  saveWebScreen.ts |       0 |        0 |       0 |       0 | 1-145             
 ...on/src/helpers |   89.55 |    93.62 |   83.33 |   89.55 |                   
  ...nshot.test.ts |     100 |      100 |     100 |     100 |                   
  ...Screenshot.ts |      80 |       20 |     100 |      80 | 56-68,73-74,78-79 
  ...nshot.test.ts |     100 |      100 |     100 |     100 |                   
  ...Screenshot.ts |   82.53 |       50 |     100 |   82.53 | 49-50,63-75,88-92 
  constants.ts     |     100 |      100 |     100 |     100 |                   
  options.test.ts  |     100 |      100 |     100 |     100 |                   
  options.ts       |   98.64 |    93.75 |     100 |   98.64 | 16                
  utils.test.ts    |     100 |      100 |     100 |     100 |                   
  utils.ts         |   49.09 |       98 |   78.94 |   49.09 | ...12-313,326-327 
 ...on/src/methods |   62.51 |    82.31 |      50 |   62.51 |                   
  ...pareReport.ts |       0 |        0 |       0 |       0 | 1-112             
  ...ntPosition.ts |   96.49 |       80 |     100 |   96.49 | 69-70             
  images.ts        |       0 |        0 |       0 |       0 | 1-670             
  ...eData.test.ts |     100 |      100 |     100 |     100 |                   
  instanceData.ts  |     100 |      100 |     100 |     100 |                   
  ...DiffPixels.ts |       0 |        0 |       0 |       0 | 1-213             
  ...ngles.test.ts |   99.26 |    85.71 |     100 |   99.26 | 189,219,249       
  rectangles.ts    |   55.49 |    89.65 |      30 |   55.49 | 156-289           
  ...shots.test.ts |     100 |      100 |     100 |     100 |                   
  screenshots.ts   |   76.41 |     74.6 |   71.42 |   76.41 | ...42-443,469-557 
 ...ison/src/mocks |     100 |      100 |     100 |     100 |                   
  mocks.ts         |     100 |      100 |     100 |     100 |                   
 scripts           |       0 |        0 |       0 |       0 |                   
  ....packages.mjs |       0 |        0 |       0 |       0 | 1-113             
-------------------|---------|----------|---------|---------|-------------------
```

</details>

<details>
<summary>New config (vitest v3) output</summary>

```
> vitest --coverage --run


 RUN  v3.0.8 
      Coverage enabled with v8

 ✓ packages/ocr-service/tests/utils/imageProcessing.test.ts (9 tests) 15ms
 ✓ packages/ocr-service/tests/service.test.ts (6 tests) 5ms
 ✓ packages/ocr-service/tests/commands/tesseract.test.ts (24 tests) 13ms
 ✓ packages/visual-service/tests/storybook/utils.test.ts (64 tests) 42ms
 ✓ packages/webdriver-image-comparison/src/methods/rectangles.test.ts (14 tests) 9ms
 ✓ packages/webdriver-image-comparison/src/helpers/utils.test.ts (46 tests) 12ms
 ✓ packages/webdriver-image-comparison/src/methods/screenshots.test.ts (9 tests) 53ms
 ✓ packages/visual-service/tests/utils.test.ts (51 tests) 15ms
 ✓ packages/ocr-service/tests/commands/ocrClickOnText.test.ts (6 tests) 9ms
 ✓ packages/ocr-service/tests/utils/ocrGetData.test.ts (5 tests) 7ms
 ✓ packages/webdriver-image-comparison/src/methods/instanceData.test.ts (4 tests) 4ms
 ✓ packages/webdriver-image-comparison/src/helpers/options.test.ts (6 tests) 4ms
 ✓ packages/visual-service/tests/reporter.test.ts (7 tests) 20ms
 ✓ packages/ocr-service/tests/commands/orcGetElementPositionByText.test.ts (3 tests) 13ms
 ✓ packages/ocr-service/tests/utils/index.test.ts (10 tests) 5ms
 ✓ packages/ocr-service/tests/utils/fuzzySearch.test.ts (4 tests) 4ms
 ✓ packages/visual-service/tests/matcher.test.ts (9 tests) 6ms
 ✓ packages/ocr-service/tests/commands/ocrSetValue.test.ts (3 tests) 8ms
 ✓ packages/visual-service/tests/service.test.ts (7 tests) 8ms
 ✓ packages/visual-service/tests/storybook/launcher.test.ts (8 tests) 8ms
 ✓ packages/webdriver-image-comparison/src/helpers/afterScreenshot.test.ts (1 test) 5ms
 ✓ packages/ocr-service/tests/commands/ocrWaitForTextDisplayed.test.ts (1 test) 6ms
 ✓ packages/ocr-service/tests/utils/ocrGetTextPositions.test.ts (2 tests) 4ms
stdout | packages/webdriver-image-comparison/src/base.test.ts > BaseClass > clears runtime folders if clearRuntimeFolder is true
2025-03-16T13:32:57.529Z INFO @wdio/visual-service:webdriver-image-comparison: [33m
##############################
!!CLEARING!!
##############################[0m

 ✓ packages/ocr-service/tests/commands/ocrGetText.test.ts (1 test) 3ms
 ✓ packages/webdriver-image-comparison/src/base.test.ts (5 tests) 6ms
 ✓ packages/ocr-service/tests/commands/ocrKeys.test.ts (3 tests) 5ms
 ✓ packages/webdriver-image-comparison/src/helpers/beforeScreenshot.test.ts (2 tests) 506ms
   ✓ beforeScreenshot > should be able to return the enriched instance data with `addShadowPadding: true` 502ms
 ✓ packages/visual-service/tests/service.expect.test.ts (1 test) 2ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/hideRemoveElements.test.ts (8 tests) 32ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopScreenNativeMobile.test.ts (3 tests) 13ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getAndroidStatusAddressToolBarHeight.test.ts (6 tests) 3ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getIosStatusAddressToolBarOffsets.test.ts (12 tests) 7ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getDocumentScrollHeight.test.ts (3 tests) 12ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/setCustomCss.test.ts (5 tests) 17ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getScreenDimensions.test.ts (3 tests) 6ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/removeElementFromDom.test.ts (4 tests) 17ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/toggleTextTransparency.test.ts (2 tests) 21ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopDom.test.ts (1 test) 9ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/hideScrollbars.test.ts (1 test) 3ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/getElementPositionTopWindow.test.ts (1 test) 10ms
 ✓ packages/webdriver-image-comparison/src/clientSideScripts/waitForFonts.test.ts (2 tests) 1005ms
   ✓ waitForFontsLoaded > should resolve if fonts load within 11 seconds 1002ms

 Test Files  41 passed (41)
      Tests  362 passed (362)
   Start at  13:32:55
   Duration  5.05s (transform 1.24s, setup 0ms, collect 6.08s, tests 1.95s, environment 7.42s, prepare 5.18s)

 HTML  Report is generated
       You can run npx vite preview --outDir .vitest-ui to see the test results.
 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   56.36 |    91.28 |   78.57 |   56.36 |                   
 __mocks__/@wdio   |     100 |      100 |     100 |     100 |                   
  logger.ts        |     100 |      100 |     100 |     100 |                   
 ...cr-service/src |   31.96 |    88.23 |      75 |   31.96 |                   
  cli.ts           |       0 |        0 |       0 |       0 | 1-175             
  index.ts         |       0 |        0 |       0 |       0 | 1-55              
  service.ts       |   81.39 |      100 |     100 |   81.39 | 74-93             
 ...e/src/commands |     100 |      100 |     100 |     100 |                   
  ...lickOnText.ts |     100 |      100 |     100 |     100 |                   
  ...tionByText.ts |     100 |      100 |     100 |     100 |                   
  ocrGetText.ts    |     100 |      100 |     100 |     100 |                   
  ocrSetValue.ts   |     100 |      100 |     100 |     100 |                   
  ...tDisplayed.ts |     100 |      100 |     100 |     100 |                   
 ...vice/src/utils |   99.58 |    96.55 |     100 |   99.58 |                   
  constants.ts     |     100 |      100 |     100 |     100 |                   
  fuzzySearch.ts   |     100 |      100 |     100 |     100 |                   
  getData.ts       |    97.1 |       80 |     100 |    97.1 | 28-29             
  ...tPositions.ts |     100 |      100 |     100 |     100 |                   
  ...Processing.ts |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
  sendKeys.ts      |     100 |      100 |     100 |     100 |                   
  tesseract.ts     |     100 |      100 |     100 |     100 |                   
 ...al-service/src |   70.12 |    93.75 |   89.58 |   70.12 |                   
  constants.ts     |     100 |      100 |     100 |     100 |                   
  index.ts         |     100 |      100 |     100 |     100 |                   
  matcher.ts       |   93.54 |    81.81 |     100 |   93.54 | 15,50-53,106-108  
  reporter.ts      |     100 |      100 |     100 |     100 |                   
  service.ts       |   43.24 |    92.85 |      75 |   43.24 | ...05-412,418-466 
  utils.ts         |   81.39 |     97.7 |   91.66 |   81.39 | ...46-347,353-402 
 .../src/storybook |   94.49 |    98.57 |     100 |   94.49 |                   
  ...escriptors.ts |     100 |      100 |     100 |     100 |                   
  launcher.ts      |    94.8 |    97.14 |     100 |    94.8 | 118-121           
  utils.ts         |   91.24 |    99.04 |     100 |   91.24 | 234-273           
 ...comparison/src |   96.15 |       90 |   66.66 |   96.15 |                   
  base.ts          |     100 |      100 |     100 |     100 |                   
  index.ts         |       0 |        0 |       0 |       0 | 1                 
 ...entSideScripts |   57.51 |    97.87 |      95 |   57.51 |                   
  ...leOnCanvas.ts |       0 |      100 |     100 |       0 | 9-316             
  ...BarOffsets.ts |     100 |      100 |     100 |     100 |                   
  ...rollHeight.ts |      80 |    83.33 |     100 |      80 | 44-49             
  ...tionTopDom.ts |     100 |      100 |     100 |     100 |                   
  ...tiveMobile.ts |     100 |      100 |     100 |     100 |                   
  ...nTopWindow.ts |     100 |      100 |     100 |     100 |                   
  ...BarOffsets.ts |     100 |      100 |     100 |     100 |                   
  ...Dimensions.ts |     100 |      100 |     100 |     100 |                   
  ...veElements.ts |     100 |      100 |     100 |     100 |                   
  ...Scrollbars.ts |   83.33 |       75 |     100 |   83.33 | 13                
  ...entFromDom.ts |     100 |      100 |     100 |     100 |                   
  ...ntIntoView.ts |       0 |      100 |     100 |       0 | 4-35              
  ...ToPosition.ts |       0 |      100 |       0 |       0 | 5-28              
  setCustomCss.ts  |     100 |      100 |     100 |     100 |                   
  ...ansparency.ts |    92.3 |      100 |     100 |    92.3 | 15                
  waitForFonts.ts  |     100 |      100 |     100 |     100 |                   
 ...n/src/commands |       0 |        0 |       0 |       0 |                   
  ...AppElement.ts |       0 |        0 |       0 |       0 | 1-79              
  ...kAppScreen.ts |       0 |        0 |       0 |       0 | 1-105             
  checkElement.ts  |       0 |        0 |       0 |       0 | 1-24              
  ...PageScreen.ts |       0 |        0 |       0 |       0 | 1-85              
  checkScreen.ts   |       0 |        0 |       0 |       0 | 1-23              
  ...bbablePage.ts |       0 |        0 |       0 |       0 | 1-46              
  ...WebElement.ts |       0 |        0 |       0 |       0 | 1-86              
  ...kWebScreen.ts |       0 |        0 |       0 |       0 | 1-78              
  ...AppElement.ts |       0 |        0 |       0 |       0 | 1-89              
  saveAppScreen.ts |       0 |        0 |       0 |       0 | 1-95              
  saveElement.ts   |       0 |        0 |       0 |       0 | 1-23              
  ...PageScreen.ts |       0 |        0 |       0 |       0 | 1-147             
  saveScreen.ts    |       0 |        0 |       0 |       0 | 1-22              
  ...bbablePage.ts |       0 |        0 |       0 |       0 | 1-36              
  ...WebElement.ts |       0 |        0 |       0 |       0 | 1-177             
  saveWebScreen.ts |       0 |        0 |       0 |       0 | 1-145             
 ...on/src/helpers |   82.28 |    89.76 |   83.33 |   82.28 |                   
  ...Screenshot.ts |      80 |       20 |     100 |      80 | 56-68,73-74,78-79 
  ...Screenshot.ts |   82.53 |       50 |     100 |   82.53 | 49-50,63-75,88-92 
  constants.ts     |     100 |      100 |     100 |     100 |                   
  options.ts       |   98.64 |    93.75 |     100 |   98.64 | 16                
  utils.ts         |   49.09 |       98 |   78.94 |   49.09 | ...12-313,326-327 
 ...on/src/methods |    37.2 |    77.22 |      50 |    37.2 |                   
  ...pareReport.ts |       0 |        0 |       0 |       0 | 1-112             
  ...ntPosition.ts |   96.49 |       80 |     100 |   96.49 | 69-70             
  images.ts        |       0 |        0 |       0 |       0 | 1-670             
  instanceData.ts  |     100 |      100 |     100 |     100 |                   
  ...DiffPixels.ts |       0 |        0 |       0 |       0 | 1-213             
  rectangles.ts    |   55.49 |    89.65 |      30 |   55.49 | 156-289           
  screenshots.ts   |   76.41 |     74.6 |   71.42 |   76.41 | ...42-443,469-557 
 ...ison/src/mocks |     100 |      100 |     100 |     100 |                   
  mocks.ts         |     100 |      100 |     100 |     100 |                   
 scripts           |       0 |        0 |       0 |       0 |                   
  ....packages.mjs |       0 |        0 |       0 |       0 | 1-113             
-------------------|---------|----------|---------|---------|-------------------
```

</details>