### PR TITLE
chore: improve executor type

### DIFF
--- a/packages/visual-service/src/service.ts
+++ b/packages/visual-service/src/service.ts
@@ -207,9 +207,11 @@ export default class WdioImageComparisonService extends BaseClass {
 
                 return command(
                     {
-                        methods:{
-                            executor: <T>(script: string | ((...innerArgs: any[]) => unknown), ...varArgs: any[]): Promise<T> => {
-                                return this.execute.bind(browser)(script, ...varArgs) as Promise<T>
+                        methods: {
+                            executor: <ReturnValue, InnerArguments extends unknown[]>(
+                                fn: string | ((...args: InnerArguments) => ReturnValue),
+                                ...args: InnerArguments): Promise<ReturnValue> => {
+                                return this.execute.bind(browser)(fn, ...args) as Promise<ReturnValue>
                             },
                             getElementRect: this.getElementRect.bind(browser),
                             screenShot: this.takeScreenshot.bind(browser),
@@ -257,8 +259,10 @@ export default class WdioImageComparisonService extends BaseClass {
                     return command(
                         {
                             methods: {
-                                executor: <T>(script: string | ((...innerArgs: any[]) => unknown), ...varArgs: any[]): Promise<T> => {
-                                    return this.execute.bind(browser)(script, ...varArgs) as Promise<T>
+                                executor: <ReturnValue, InnerArguments extends unknown[]>(
+                                    fn: string | ((...args: InnerArguments) => ReturnValue),
+                                    ...args: InnerArguments): Promise<ReturnValue> => {
+                                    return this.execute.bind(browser)(fn, ...args) as Promise<ReturnValue>
                                 },
                                 getElementRect: this.getElementRect.bind(browser),
                                 screenShot: this.takeScreenshot.bind(browser),
@@ -309,9 +313,11 @@ export default class WdioImageComparisonService extends BaseClass {
 
                     returnData[browserName] = await command(
                         {
-                            methods:{
-                                executor: <T>(script: string | ((...innerArgs: any[]) => unknown), ...varArgs: any[]): Promise<T> => {
-                                    return browserInstance.execute.bind(browserInstance)(script, ...varArgs) as Promise<T>
+                            methods: {
+                                executor: <ReturnValue, InnerArguments extends unknown[]>(
+                                    fn: string | ((...args: InnerArguments) => ReturnValue),
+                                    ...args: InnerArguments): Promise<ReturnValue> => {
+                                    return this.execute.bind(browser)(fn, ...args) as Promise<ReturnValue>
                                 },
                                 getElementRect: browserInstance.getElementRect.bind(browserInstance),
                                 screenShot: browserInstance.takeScreenshot.bind(browserInstance),
@@ -368,8 +374,10 @@ export default class WdioImageComparisonService extends BaseClass {
                         returnData[browserName] = await command(
                             {
                                 methods: {
-                                    executor: <T>(script: string | ((...innerArgs: any[]) => unknown), ...varArgs: any[]): Promise<T> => {
-                                        return browserInstance.execute.bind(browserInstance)(script, ...varArgs) as Promise<T>
+                                    executor: <ReturnValue, InnerArguments extends unknown[]>(
+                                        fn: string | ((...args: InnerArguments) => ReturnValue),
+                                        ...args: InnerArguments): Promise<ReturnValue> => {
+                                        return this.execute.bind(browser)(fn, ...args) as Promise<ReturnValue>
                                     },
                                     getElementRect: browserInstance.getElementRect.bind(browserInstance),
                                     screenShot: browserInstance.takeScreenshot.bind(browserInstance),

--- a/packages/webdriver-image-comparison/src/clientSideScripts/hideRemoveElements.ts
+++ b/packages/webdriver-image-comparison/src/clientSideScripts/hideRemoveElements.ts
@@ -7,7 +7,7 @@ export default function hideRemoveElements(
         remove: (HTMLElement | HTMLElement[])[];
     },
     hideRemove: boolean,
-): any {
+) {
     const visitedSelectors: Record<string, boolean> = {}
     hideRemoveElements.hide.forEach((element) => {
         if (Array.isArray(element)) {

--- a/packages/webdriver-image-comparison/src/methods/elementPosition.ts
+++ b/packages/webdriver-image-comparison/src/methods/elementPosition.ts
@@ -6,7 +6,6 @@ import type { Executor } from './methods.interfaces.js'
 import type { ElementPosition } from '../clientSideScripts/elementPosition.interfaces.js'
 import getAndroidStatusAddressToolBarOffsets from '../clientSideScripts/getAndroidStatusAddressToolBarOffsets.js'
 import getIosStatusAddressToolBarOffsets from '../clientSideScripts/getIosStatusAddressToolBarOffsets.js'
-import type { StatusAddressToolBarOffsets } from '../clientSideScripts/statusAddressToolBarOffsets.interfaces.js'
 
 /**
  * Get the element position on a Android device
@@ -24,9 +23,7 @@ export async function getElementPositionAndroid(
             screenWidth,
             sideBar: { width: sideBarWidth },
             statusAddressBar: { height },
-        } = <StatusAddressToolBarOffsets>(
-            await executor(getAndroidStatusAddressToolBarOffsets, ANDROID_OFFSETS, { isHybridApp: false, isLandscape })
-        )
+        } = await executor(getAndroidStatusAddressToolBarOffsets, ANDROID_OFFSETS, { isHybridApp: false, isLandscape })
 
         return executor(getElementPositionTopScreenNativeMobile, element, {
             isLandscape,
@@ -84,7 +81,7 @@ export async function getElementPositionIos(
         screenWidth,
         sideBar: { width: sideBarWidth },
         statusAddressBar: { height },
-    } = <StatusAddressToolBarOffsets> await executor(getIosStatusAddressToolBarOffsets, IOS_OFFSETS, isLandscape)
+    } = await executor(getIosStatusAddressToolBarOffsets, IOS_OFFSETS, isLandscape)
 
     return executor(getElementPositionTopScreenNativeMobile, element, {
         isLandscape,

--- a/packages/webdriver-image-comparison/src/methods/instanceData.ts
+++ b/packages/webdriver-image-comparison/src/methods/instanceData.ts
@@ -12,7 +12,6 @@ import {
 import getScreenDimensions from '../clientSideScripts/getScreenDimensions.js'
 import type { Executor } from './methods.interfaces.js'
 import type { EnrichedInstanceData, InstanceOptions } from './instanceData.interfaces.js'
-import type { ScreenDimensions } from '../clientSideScripts/screenDimensions.interfaces.js'
 
 /**
  * Enrich the instance data with more data
@@ -23,7 +22,7 @@ export default async function getEnrichedInstanceData(
     addShadowPadding: boolean,
 ): Promise<EnrichedInstanceData> {
     // Get the current browser data
-    const browserData: ScreenDimensions = await executor(getScreenDimensions)
+    const browserData = await executor(getScreenDimensions)
     const { addressBarShadowPadding, toolBarShadowPadding, browserName, nativeWebScreenshot, platformName } = instanceOptions
 
     // Determine some constants

--- a/packages/webdriver-image-comparison/src/methods/methods.interfaces.ts
+++ b/packages/webdriver-image-comparison/src/methods/methods.interfaces.ts
@@ -1,7 +1,11 @@
 import type { RectanglesOutput } from './rectangles.interfaces.js'
 
-export type Executor = <T>(script: string | Function, ...varArgs: any[]) => Promise<T>;
-export type GetElementRect = (elementId:string) => Promise<RectanglesOutput>
+/** Binding to the `await browser.execute()` method */
+export type Executor = <ReturnValue, InnerArguments extends unknown[]>(
+    fn: string | ((...args: InnerArguments) => ReturnValue),
+    ...args: InnerArguments
+) => Promise<ReturnValue>;
+export type GetElementRect = (elementId: string) => Promise<RectanglesOutput>
 export type TakeScreenShot = () => Promise<string>;
 export type TakeElementScreenshot = (elementId: string) => Promise<string>;
 

--- a/packages/webdriver-image-comparison/src/methods/screenshots.ts
+++ b/packages/webdriver-image-comparison/src/methods/screenshots.ts
@@ -14,7 +14,6 @@ import type {
     TakeWebElementScreenshot,
     TakeWebElementScreenshotData,
 } from './screenshots.interfaces.js'
-import type { StatusAddressToolBarOffsets } from '../clientSideScripts/statusAddressToolBarOffsets.interfaces.js'
 import hideRemoveElements from '../clientSideScripts/hideRemoveElements.js'
 import hideScrollBars from '../clientSideScripts/hideScrollbars.js'
 import type { ElementRectanglesOptions } from './rectangles.interfaces.js'
@@ -68,9 +67,7 @@ export async function getBase64FullPageScreenshotsData(
             screenWidth,
             sideBar: { width: sideBarWidth },
             statusAddressBar: { height: statusAddressBarHeight },
-        } = <StatusAddressToolBarOffsets>(
-            await executor(getAndroidStatusAddressToolBarOffsets, ANDROID_OFFSETS, { isHybridApp, isLandscape })
-        )
+        } = await executor(getAndroidStatusAddressToolBarOffsets, ANDROID_OFFSETS, { isHybridApp, isLandscape })
 
         const androidNativeMobileOptions = {
             ...nativeMobileOptions,
@@ -97,7 +94,8 @@ export async function getBase64FullPageScreenshotsData(
             sideBar: { width: sideBarWidth },
             statusAddressBar: { height: statusAddressBarHeight },
             toolBar: { y: iosHomeBarY },
-        } = <StatusAddressToolBarOffsets> await executor(getIosStatusAddressToolBarOffsets, IOS_OFFSETS, isLandscape)
+        } = await executor(getIosStatusAddressToolBarOffsets, IOS_OFFSETS, isLandscape)
+
         const iosNativeMobileOptions = {
             ...nativeMobileOptions,
             iosHomeBarY,


### PR DESCRIPTION
### Description

While trying to implement `@wdio/eslint` I noticed that `Executor` type was loosely defined, this should now infer the correct type from the function that is passed.
With the type inference, we can remove some castings.