### PR TITLE
feat: add `additionalSearchParams` API to Storybook Runner

### DIFF
--- a/.changeset/early-timers-crash.md
+++ b/.changeset/early-timers-crash.md
@@ -1,0 +1,6 @@
+---
+"webdriver-image-comparison": minor
+"@wdio/visual-service": minor
+---
+
+Add `additionalSearchParams` to the Storybook Runner API

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ export const config: WebdriverIO.Config  = {
 
 ### Storybook Runner CLI options
 
+#### `--additionalSearchParams`
+
+-   **Type:** `string`
+-   **Mandatory:** No
+-   **Default:** ''
+-   **Example:** `npx wdio tests/configs/wdio.local.desktop.storybook.conf.ts --storybook --additionalSearchParams="foo=bar&abc=def"`
+
+It will add additional search parameters to the Storybook URL.
+See the [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) documentation for more information. The string must be a valid URLSearchParams string.
+
+> [!NOTE]
+> The double quotes are needed to prevent the `&` from being interpreted as a command separator.
+> For example with `--additionalSearchParams="foo=bar&abc=def"` it will generate the following Storybook URL for stories test: `http://storybook.url/iframe.html?id=story-id&foo=bar&abc=def`.
+
 #### `--browsers`
 
 -   **Type:** `string`

--- a/packages/visual-service/src/storybook/Types.ts
+++ b/packages/visual-service/src/storybook/Types.ts
@@ -30,6 +30,7 @@ export interface StoriesRes {
 export type Stories = { [key: string]: StorybookData };
 
 export type CreateTestFileOptions = {
+    additionalSearchParams: URLSearchParams;
     clip: boolean;
     clipSelector: string;
     directoryPath: string,
@@ -49,6 +50,7 @@ export interface CapabilityMap {
 }
 
 export type CreateTestContent = {
+    additionalSearchParams: URLSearchParams;
     clip: boolean;
     clipSelector: string;
     folders: Folders;
@@ -59,6 +61,7 @@ export type CreateTestContent = {
 }
 
 export type CreateItContent = {
+    additionalSearchParams: URLSearchParams;
     clip: boolean;
     clipSelector: string;
     folders: Folders;
@@ -83,6 +86,13 @@ export type EmulatedDeviceType = {
 }
 
 export type WaitForStorybookComponentToBeLoaded = {
+    /**
+     * Additional search parameters to be added to the Storybook URL
+     *
+     * @example addtionalSearchParams: new URLSearchParams({ foo: 'bar', abc: 'def' })
+     * This will generate the following Storybook URL for stories test: `http://storybook.url/iframe.html?id=story-id&foo=bar&abc=def`
+     */
+    additionalSearchParams?: URLSearchParams;
     clipSelector?: string,
     id: string;
     timeout?: number,

--- a/packages/visual-service/src/storybook/launcher.ts
+++ b/packages/visual-service/src/storybook/launcher.ts
@@ -78,9 +78,14 @@ export default class VisualLauncher extends BaseClass  {
             const skipStoriesArgv = getArgvValue('--skipStories', value => value)
             const skipStories = skipStoriesOption ?? skipStoriesArgv ?? []
             const parsedSkipStories = parseSkipStories(skipStories)
+            // --additionalSearchParams
+            const additionalSearchParamsOption = this.#options?.storybook?.additionalSearchParams
+            const additionalSearchParamsArgv = getArgvValue('--additionalSearchParams', value => new URLSearchParams(value))
+            const additionalSearchParams = additionalSearchParamsOption ?? additionalSearchParamsArgv ?? new URLSearchParams()
 
             // Create the test files
             createTestFiles({
+                additionalSearchParams,
                 clip,
                 clipSelector,
                 directoryPath: tempDir,

--- a/packages/visual-service/tests/storybook/__snapshots__/utils.test.ts.snap
+++ b/packages/visual-service/tests/storybook/__snapshots__/utils.test.ts.snap
@@ -123,6 +123,7 @@ exports[`Storybook utils > itFunction > generates correct mocha test code with n
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });
@@ -136,6 +137,7 @@ exports[`Storybook utils > itFunction > generates correct mocha test code with s
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });
@@ -149,6 +151,7 @@ exports[`Storybook utils > itFunction > generates correct test code with Jasmine
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });
@@ -162,6 +165,7 @@ exports[`Storybook utils > itFunction > generates correct test code with Jasmine
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });
@@ -175,6 +179,7 @@ exports[`Storybook utils > itFunction > generates correct test code with for a c
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect($('#id')).toMatchElementSnapshot('category-component--story1-element', {"baselineFolder":"baseline/category/component/"})
     });
@@ -188,6 +193,7 @@ exports[`Storybook utils > itFunction > generates correct test code with for a c
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect($('#id')).toMatchElementSnapshot('category-component--story1-element', {"baselineFolder":"baseline/category/component/"})
     });
@@ -201,6 +207,7 @@ exports[`Storybook utils > itFunction > generates correct test code with mocha f
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });
@@ -214,6 +221,7 @@ exports[`Storybook utils > itFunction > generates correct test code with mocha f
             clipSelector: '#id',
             id: 'category-component--story1',
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams('foo=bar'),
         });
         await expect(browser).toMatchScreenSnapshot('category-component--story1', {"baselineFolder":"baseline/category/component/"})
     });

--- a/packages/visual-service/tests/storybook/launcher.test.ts
+++ b/packages/visual-service/tests/storybook/launcher.test.ts
@@ -57,7 +57,7 @@ describe('Visual Launcher for Storybook', () => {
             expect(vi.mocked(storybookUtils.isCucumberFramework)).toHaveBeenCalledOnce()
             expect(logInfoMock.mock.calls[0][0]).toMatchSnapshot()
             expect(logInfoMock.mock.calls[1][0]).toMatchSnapshot()
-            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(5)
+            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(6)
             expect(vi.mocked(storybookUtils.parseSkipStories)).toHaveBeenCalledWith([])
             expect(vi.mocked(storybookUtils.createTestFiles)).toHaveBeenCalled()
             expect(vi.mocked(storybookUtils.createStorybookCapabilities)).toHaveBeenCalled()
@@ -73,10 +73,11 @@ describe('Visual Launcher for Storybook', () => {
                 .mockReturnValueOnce(false) // --clip
                 .mockReturnValueOnce(undefined) // --clipSelector
                 .mockReturnValueOnce(['foo-bar-foo']) // --skipStories
+                .mockReturnValueOnce('foo=bar') // --additionalSearchParams
 
             await Launcher.onPrepare(config, caps)
 
-            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(5)
+            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(6)
             expect(vi.mocked(storybookUtils.parseSkipStories)).toHaveBeenCalledWith(['foo-bar-foo'])
         })
 
@@ -85,11 +86,11 @@ describe('Visual Launcher for Storybook', () => {
                 throw new Error('onPrepare method is not defined on Launcher')
             }
 
-            options.storybook = { version: 7, numShards: 16, clip: false, clipSelector: 'clipSelector', skipStories: 'skipStories' }
+            options.storybook = { version: 7, numShards: 16, clip: false, clipSelector: 'clipSelector', skipStories: 'skipStories', additionalSearchParams: new URLSearchParams({ foo: 'bar' }) }
 
             await Launcher.onPrepare(config, caps)
 
-            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(5)
+            expect(vi.mocked(storybookUtils.getArgvValue)).toHaveBeenCalledTimes(6)
             expect(vi.mocked(storybookUtils.parseSkipStories)).toHaveBeenCalledWith('skipStories')
         })
 

--- a/packages/visual-service/tests/storybook/utils.test.ts
+++ b/packages/visual-service/tests/storybook/utils.test.ts
@@ -272,6 +272,7 @@ describe('Storybook utils', () => {
             skipStories,
             storyData: { id: 'category-component--story1' },
             storybookUrl: 'http://storybook.com/',
+            additionalSearchParams: new URLSearchParams({ foo: 'bar' })
         })
 
         it('generates correct test code with Jasmine framework and skip array', () => {
@@ -496,6 +497,21 @@ describe('Storybook utils', () => {
             expect(mock$).toHaveBeenCalledWith('.storybook-component')
             expect(mock$.mock.results[0].value.waitForDisplayed).toHaveBeenCalled()
             expect(mockBrowser.executeAsync).toHaveBeenCalled()
+        })
+
+        it('should go to the correct URL when given additionalSearchParams', async () => {
+            const mockStorybookModeFunction = vi.fn().mockReturnValue(true)
+            const options = {
+                url: 'http://localhost:6006/',
+                id: 'example-component',
+                additionalSearchParams: new URLSearchParams({ foo: 'bar', baz: 'qux' }),
+            }
+
+            await waitForStorybookComponentToBeLoaded(options, mockStorybookModeFunction)
+
+            // Assertions
+            expect(mockBrowser.url).toHaveBeenCalledWith('http://localhost:6006/iframe.html?id=example-component&foo=bar&baz=qux')
+
         })
     })
 

--- a/packages/webdriver-image-comparison/src/helpers/options.interfaces.ts
+++ b/packages/webdriver-image-comparison/src/helpers/options.interfaces.ts
@@ -103,6 +103,14 @@ export interface ClassOptions {
         url?: string;
         // Version of the storybook, default is 7
         version?: number
+        /**
+         * Additional search parameters to be added to the Storybook URL
+         *
+         * @example { additionalSearchParams: new URLSearchParams({ 'foo': 'bar' }) }
+         * This will generate the following Storybook URL for stories test: `http://storybook.url/iframe.html?id=story-id&foo=bar`
+         *
+         */
+        additionalSearchParams?: URLSearchParams;
     }
 }
 


### PR DESCRIPTION
## Description

This adds the feature to include additional search params to the Storybook URL. 
This is very useful when you have for example different themes using the CSS Variables Theme addon ([docs](https://github.com/etchteam/storybook-addon-css-variables-theme?tab=readme-ov-file#set-a-theme-by-query-string)) or if we want to use Controls on a specific story (`&args=myControl:updateValue`).