### PR TITLE
ci: fix backtick parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,11 @@ jobs:
           PR_TITLE="${{ github.event.pull_request.title }}"
           UNIT_TEST_REGEX='(@typescript-eslint|vitest|eslint|@types|@tsconfig|ts-node|jsdom|typescript)'
           WEB_TEST_REGEX='(@wdio(?!\/appium-service)|copyfiles|rimraf|saucelabs|lambdatest|webdriverio)'
-          if [[ $PR_TITLE =~ $UNIT_TEST_REGEX ]]; then
-            echo "::set-output name=run_unit_tests::true"
+          if [[ "$PR_TITLE" =~ $UNIT_TEST_REGEX ]]; then
+            echo "run_unit_tests=true" >> $GITHUB_OUTPUT
           fi
-          if [[ $PR_TITLE =~ $WEB_TEST_REGEX ]]; then
-            echo "::set-output name=run_web_tests::true"
+          if [[ "$PR_TITLE" =~ $WEB_TEST_REGEX ]]; then
+            echo "run_web_tests=true" >> $GITHUB_OUTPUT
           fi
 
   ci-dependency-unit-test:


### PR DESCRIPTION
Pull requests titles that include backticks will make the CI fail because they are evaluated as valid bash characters, surrounding it with double quotes should force it to be a string.

Also removing the deprecated `::set-output` ([docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows))