### PR TITLE
chore: setup pnpm using corepack

### DIFF
--- a/.github/workflows/alpha.release.yml
+++ b/.github/workflows/alpha.release.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: 🔧 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🔧 Setup NPM
         run: |

--- a/.github/workflows/deploy-visual-reporter.yml
+++ b/.github/workflows/deploy-visual-reporter.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/checkout@v4
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: 🔧 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🔧 Setup NPM
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -91,8 +89,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -156,8 +152,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -221,8 +215,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -286,8 +278,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -351,8 +341,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -416,8 +404,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: 🟢 Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -507,7 +507,6 @@ To create a PR for this project and start contributing follow this step-by-step 
     ```sh
     $ cd visual-testing
     $ corepack enable
-    $ corepack use pnpm@8.x
     $ pnpm pnpm.install.workaround
     ```
 

--- a/package.json
+++ b/package.json
@@ -93,5 +93,6 @@
     "vitest": "^3.0.8",
     "wdio-lambdatest-service": "^4.0.0",
     "webdriverio": "^9.9.1"
-  }
+  },
+  "packageManager": "pnpm@9.15.9+sha256.cf86a7ad764406395d4286a6d09d730711720acc6d93e9dce9ac7ac4dc4a28a7"
 }


### PR DESCRIPTION
Enable the setup of the project using `corepack` to install a specific version of `pnpm`.  

This improves consistency between contributors and makes it easier for new contributors to get started with the project.

Reference: https://pnpm.io/installation#using-corepack