### PR TITLE
chore: remove duplicated expect-webdriverio type

### DIFF
--- a/packages/visual-service/package.json
+++ b/packages/visual-service/package.json
@@ -29,7 +29,7 @@
     "@wdio/globals": "^9.9.1",
     "@wdio/logger": "^9.4.4",
     "@wdio/types": "^9.9.0",
+    "expect-webdriverio": "^5.1.0",
     "webdriver-image-comparison": "workspace:*"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/visual-service/src/index.ts
+++ b/packages/visual-service/src/index.ts
@@ -165,14 +165,6 @@ declare global {
                 options?: WdioCheckFullPageMethodOptions
             ): R
         }
-        // This is a workaround, copied this from the expect-webdriverio package
-        // https://github.com/webdriverio/expect-webdriverio/blob/main/types/expect-webdriverio.d.ts#L444
-        interface PartialMatcher {
-            sample?: any
-            $$typeof: symbol
-            asymmetricMatch(...args: any[]): boolean
-            toString(): string
-        }
     }
 }
 export type { VisualServiceOptions }

--- a/packages/visual-service/tsconfig.json
+++ b/packages/visual-service/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "types": ["expect-webdriverio"]
   },
   "include": ["./src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@wdio/types':
         specifier: ^9.9.0
         version: 9.9.0
+      expect-webdriverio:
+        specifier: ^5.1.0
+        version: 5.1.0(@wdio/globals@9.9.1(@wdio/logger@9.4.4))(@wdio/logger@9.4.4)(webdriverio@9.9.1)
       webdriver-image-comparison:
         specifier: workspace:*
         version: link:../webdriver-image-comparison


### PR DESCRIPTION
While working on bumping ESLint, the `any` from this interface was causing some issues.

This type is a duplicate of the one already in `expect-webdriverio`. As we actually already include this package, this should not have any impact, and actually make it more clear that `visual-service` extends the matchers.

```bash
$ pnpm why expect-webdriverio
@wdio/visual-service link:packages/visual-service
└─┬ @wdio/globals 9.9.1
  └── expect-webdriverio 5.1.0
  ```