### PR TITLE
fix: DPR issue with takeElementScreenshot in web

### DIFF
--- a/.changeset/tender-teeth-fail.md
+++ b/.changeset/tender-teeth-fail.md
@@ -1,0 +1,5 @@
+---
+"webdriver-image-comparison": patch
+---
+
+Fix an issue in Web where the takeElementScreenshot does not consider the DPR of the device

--- a/packages/webdriver-image-comparison/src/commands/saveWebElement.ts
+++ b/packages/webdriver-image-comparison/src/commands/saveWebElement.ts
@@ -90,7 +90,8 @@ export default async function saveWebElement(
         isIOS,
         isLandscape,
         // When the element needs to be resized, we need to take a screenshot of the whole page
-        fallback: !!saveElementOptions.method.resizeDimensions || false,
+        // or when devicePixelRatio is different than 1 as the browser takeElementScreenshot does not consider DPR
+        fallback: (devicePixelRatio && devicePixelRatio > 1) || !!saveElementOptions.method.resizeDimensions || false,
         screenShot,
         takeElementScreenshot,
     })


### PR DESCRIPTION
When taking an element screenshot in web, the DPR is not taken into account.
This fix adds a bypass for DPR > 1 to use the fallback solution (full screenshot then resizing)