### PR TITLE
fix: fix capturing non-static positioned elements via bidi interface

### DIFF
--- a/.changeset/hot-carrots-appear.md
+++ b/.changeset/hot-carrots-appear.md
@@ -1,0 +1,6 @@
+---
+"webdriver-image-comparison": patch
+"@wdio/visual-service": patch
+---
+
+Fix capturing element screenshots with BiDi

--- a/.changeset/hot-carrots-appear.md
+++ b/.changeset/hot-carrots-appear.md
@@ -4,3 +4,10 @@
 ---
 
 Fix capturing element screenshots with BiDi
+
+This release fixes #919 where an element screenshot, that was for example from an overlay, dropdown, popover, tooltip, modal, was returning an incorrect screenshot
+
+## Committers: 1
+
+-   Wim Selles ([@wswebcreation](https://github.com/wswebcreation))
+


### PR DESCRIPTION
This fixes #919. 