### PR TITLE
Fix for issues_657 and issue_983

### DIFF
--- a/.changeset/spotty-bananas-glow.md
+++ b/.changeset/spotty-bananas-glow.md
@@ -1,0 +1,9 @@
+---
+"@wdio/ocr-service": minor
+---
+
+\- improve typing for executor (as previously done in webdriverio package)
+
+\- For both ocr-service and visual-service, the functions are now first add to the browser object and then to each instances to avoid having the loop for each instance in the command of a single instance (function with the loop no longer call itself like in the issue 657 and are now correctly declared to the correct element to fix issue 983)
+
+\- Update the clean script for visual-reporter to work with Windows

--- a/packages/visual-reporter/package.json
+++ b/packages/visual-reporter/package.json
@@ -17,7 +17,7 @@
     "build": "run-s clean build:*",
     "build:report": "remix vite:build",
     "build:scripts": "tsc -p tsconfig.scripts.json",
-    "clean": "rimraf coverage build *.tsbuildinfo",
+    "clean": "rimraf coverage build --glob *.tsbuildinfo",
     "dev": "cross-env VISUAL_REPORT_LOCAL_DEV=true run-s build:scripts script:prepare.report && run-p watch:scripts dev:remix",
     "dev:remix": "remix vite:dev",
     "script:prepare.report": "node ./dist/prepareReportAssets.js",

--- a/packages/visual-service/src/service.ts
+++ b/packages/visual-service/src/service.ts
@@ -2,6 +2,7 @@ import logger from '@wdio/logger'
 import { expect } from '@wdio/globals'
 import { dirname, normalize, resolve } from 'node:path'
 import type { Capabilities, Frameworks } from '@wdio/types'
+import type { TransformElement } from 'webdriverio'
 import {
     BaseClass,
     checkElement,
@@ -142,7 +143,14 @@ export default class WdioImageComparisonService extends BaseClass {
         const browserNames = Object.keys(capabilities)
 
         /**
-         * Add all the commands to each browser in the Multi Remote
+         * Add all commands to the global browser object that will execute on each browser in the Multi Remote.
+         */
+        for (const [commandName, command] of Object.entries(pageCommands)) {
+            this.#addMultiremoteCommand(browser, browserNames, commandName, command)
+        }
+
+        /**
+         * Add all commands to each instance (but Single Remote version)
          */
         for (const browserName of browserNames) {
             log.info(`Adding commands to Multi Browser: ${browserName}`)
@@ -153,15 +161,6 @@ export default class WdioImageComparisonService extends BaseClass {
             this._contextManagers?.set(browserName, contextManager)
 
             await this.#addCommandsToBrowser(browserInstance)
-        }
-
-        /**
-         * Add all the commands to the global browser object that will execute
-         * on each browser in the Multi Remote
-         * Start with the page commands
-         */
-        for (const [commandName, command] of Object.entries(pageCommands)) {
-            this.#addMultiremoteCommand(browser, browserNames, commandName, command)
         }
 
         /**
@@ -234,7 +233,7 @@ export default class WdioImageComparisonService extends BaseClass {
                             methods: {
                                 bidiScreenshot: isBiDiScreenshotSupported(browser) ? this.browsingContextCaptureScreenshot.bind(browser) : undefined,
                                 executor: <ReturnValue, InnerArguments extends unknown[]>(
-                                    fn: string | ((...args: InnerArguments) => ReturnValue),
+                                    fn: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
                                     ...args: InnerArguments
                                 ): Promise<ReturnValue> => {
                                     return this.execute(fn, ...args) as Promise<ReturnValue>
@@ -311,7 +310,7 @@ export default class WdioImageComparisonService extends BaseClass {
                             methods: {
                                 bidiScreenshot: isBiDiScreenshotSupported(browser) ? this.browsingContextCaptureScreenshot.bind(browser) : undefined,
                                 executor: <ReturnValue, InnerArguments extends unknown[]>(
-                                    fn: string | ((...args: InnerArguments) => ReturnValue),
+                                    fn: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
                                     ...args: InnerArguments
                                 ): Promise<ReturnValue> => {
                                     return this.execute(fn, ...args) as Promise<ReturnValue>
@@ -387,7 +386,7 @@ export default class WdioImageComparisonService extends BaseClass {
                                 methods: {
                                     bidiScreenshot: isBiDiScreenshotSupported(browserInstance) ? browserInstance.browsingContextCaptureScreenshot.bind(browserInstance) : undefined,
                                     executor: <ReturnValue, InnerArguments extends unknown[]>(
-                                        fn: string | ((...args: InnerArguments) => ReturnValue),
+                                        fn: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
                                         ...args: InnerArguments
                                     ): Promise<ReturnValue> => {
                                         return browserInstance.execute(fn, ...args) as Promise<ReturnValue>
@@ -480,7 +479,7 @@ export default class WdioImageComparisonService extends BaseClass {
                                 methods: {
                                     bidiScreenshot: isBiDiScreenshotSupported(browserInstance) ? browserInstance.browsingContextCaptureScreenshot.bind(browserInstance) : undefined,
                                     executor: <ReturnValue, InnerArguments extends unknown[]>(
-                                        fn: string | ((...args: InnerArguments) => ReturnValue),
+                                        fn: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
                                         ...args: InnerArguments
                                     ): Promise<ReturnValue> => {
                                         return browserInstance.execute(fn, ...args) as Promise<ReturnValue>

--- a/packages/visual-service/src/utils.ts
+++ b/packages/visual-service/src/utils.ts
@@ -2,6 +2,7 @@ import type { Capabilities } from '@wdio/types'
 import type { AppiumCapabilities } from 'node_modules/@wdio/types/build/Capabilities.js'
 import { getMobileScreenSize, getMobileViewPortPosition, IOS_OFFSETS, NOT_KNOWN } from 'webdriver-image-comparison'
 import type { Folders, InstanceData, TestContext } from 'webdriver-image-comparison'
+import type { TransformElement, TransformReturn } from 'webdriverio'
 import type {
     EnrichTestContextOptions,
     getFolderMethodOptions,
@@ -70,8 +71,8 @@ async function getMobileInstanceData({
 
     if (isMobile) {
         const executor = <ReturnValue, InnerArguments extends unknown[]>(
-            fn: string | ((...args: InnerArguments) => ReturnValue),
-            ...args: InnerArguments) => currentBrowser.execute(fn, ...args) as Promise<ReturnValue>
+            fn: string | ((...innerArgs: TransformElement<InnerArguments>) => ReturnValue),
+            ...args: InnerArguments) => currentBrowser.execute(fn, ...args) as Promise<TransformReturn<ReturnValue>>
         const getUrl = () => currentBrowser.getUrl()
         const url = (arg:string) => currentBrowser.url(arg)
         const currentDriverCapabilities = currentBrowser.capabilities

--- a/packages/webdriver-image-comparison/src/methods/methods.interfaces.ts
+++ b/packages/webdriver-image-comparison/src/methods/methods.interfaces.ts
@@ -1,15 +1,15 @@
 import type { RectanglesOutput } from './rectangles.interfaces.js'
-
+import type { TransformReturn, TransformElement } from 'webdriverio'
 // There a multiple ways to call the executor method, for mobile and web
-type ExecuteScript = <ReturnValue, Args extends unknown[]>(
-    fn: (...args: Args) => ReturnValue,
-    ...args: Args
-  ) => Promise<ReturnValue>;
+type ExecuteScript = <ReturnValue, InnerArguments extends unknown[]>(
+    fn: (...innerArgs: TransformElement<InnerArguments>) => ReturnValue,
+    ...args: InnerArguments
+  ) => Promise<TransformReturn<ReturnValue>>;
 
 type ExecuteMobile = <ReturnValue>(
     fn: string,
     args?: Record<string, any>
-) => Promise<ReturnValue>;
+) => Promise<TransformReturn<ReturnValue>>;
 interface BrowsingContextCaptureScreenshotParameters {
     context: string;
     origin?: 'viewport' | 'document';


### PR DESCRIPTION
Hello

### 📝 Description
Attempt to fix:
- [issue 657](https://github.com/webdriverio/visual-testing/issues/657)
- [issue 983](https://github.com/webdriverio/visual-testing/issues/983)

---

### 💡 Explanation

In the previous version of the code, the OCR function was added first to each instance of the browser and then to the browser object.

The problem is, `@wdio\utils\build\index.js` (line 388) already add the command to each instance so the commande added to each instance was overwritten by the one containing the loop of each instance.

→ Resulting in the [issue 983](https://github.com/webdriverio/visual-testing/issues/983)

This issue was also the reason of the loop from [issue 657](https://github.com/webdriverio/visual-testing/issues/657), because each instance called the multi remote version of the command when we use:
`browserInstance[commandName].apply(browserInstance, args)`

### ✏️ Modifications

1. Tried to update the type to be compatible with the change done in this [webdriverio commit](https://github.com/webdriverio/webdriverio/commit/bc5a7438cc8a402099ed9797adcc8ca4549012d9), without this change, the build was not possible.

→ I'm not really confident about this part
 
2. Change the addCommand order for Multi Remote
   - first, add the command to Browser in a Multi Remote version (with a loop to do the function in each instance)
   - then, add the command to each instance in a Single Remote version 
In both ocr-service and visual-service

3. Inside the package.json of visual reporter: 
`"clean": "rimraf coverage build *.tsbuildinfo"`
is replaced by:
`"clean": "rimraf coverage build --glob *.tsbuildinfo"`
Because without that, it will fail on Windows in pathArg check :
```
    if (platform === 'win32') {
        const badWinChars = /[*|"<>?:]/;
        const { root } = parse(path);
        if (badWinChars.test(path.substring(root.length))) {
            throw Object.assign(new Error('Illegal characters in path.'), {
                path,
                code: 'EINVAL',
            });
        }
    }
```

### ⚠️ Warnings
I'm not a javascript/typescript expert so maybe:
- it's overkill, 
- some changes are useless,
- some changes are perfectible,
- some changes doesn't follow good practice

But at least it work with both calls from `Browser` or `MultiRemoteBrowser` and no longer loop.

---

Best regard,
Paul