### PR TITLE
Issue 983 for main

### DIFF
--- a/.changeset/upset-areas-wear.md
+++ b/.changeset/upset-areas-wear.md
@@ -1,0 +1,5 @@
+---
+"@wdio/visual-service": patch
+---
+
+fix: in multiremote, commands are now executed on the requested instances

--- a/.changeset/upset-areas-wear.md
+++ b/.changeset/upset-areas-wear.md
@@ -2,4 +2,4 @@
 "@wdio/visual-service": patch
 ---
 
-fix: in multiremote, commands are now executed on the requested instances
+fix: [983](#983 ) in multiremote, commands are now executed on the requested instances

--- a/packages/visual-service/src/service.ts
+++ b/packages/visual-service/src/service.ts
@@ -141,6 +141,15 @@ export default class WdioImageComparisonService extends BaseClass {
         const browserNames = Object.keys(capabilities)
 
         /**
+         * Add all the commands to the global browser object that will execute
+         * on each browser in the Multi Remote
+         * Start with the page commands
+         */
+        for (const [commandName, command] of Object.entries(pageCommands)) {
+            this.#addMultiremoteCommand(browser, browserNames, commandName as keyof CommandMap, command)
+        }
+
+        /**
          * Add all the commands to each browser in the Multi Remote
          */
         for (const browserName of browserNames) {
@@ -152,15 +161,6 @@ export default class WdioImageComparisonService extends BaseClass {
             this._contextManagers?.set(browserName, contextManager)
 
             await this.#addCommandsToBrowser(browserInstance)
-        }
-
-        /**
-         * Add all the commands to the global browser object that will execute
-         * on each browser in the Multi Remote
-         * Start with the page commands
-         */
-        for (const [commandName, command] of Object.entries(pageCommands)) {
-            this.#addMultiremoteCommand(browser, browserNames, commandName as keyof CommandMap, command)
         }
 
         /**


### PR DESCRIPTION
### 📝 Description
This PR is a fix for [issue 983](https://github.com/webdriverio/visual-testing/issues/983).

---

### 🐛 Bug

In the previous version of the code, the functions was added first to each instance of the browser and then to the browser object.

The problem is, `@wdio\utils\build\index.js` (line 388) already add the command to each instance so the commande added to each instance was overwritten by the one containing the loop of each instance.

---

### 🛠️ Solution

Change the addCommand order for Multi Remote
   - first, add the command to Browser in a Multi Remote version (with a loop to do the function in each instance)
   - then, add the command to each instance in a Single Remote version 
For ocr-service