### PR TITLE
fix(disableBlinkingCursor): caret-color was not applied in shadowdom …

### DIFF
--- a/.changeset/blinking-cursor-shadowdom.md
+++ b/.changeset/blinking-cursor-shadowdom.md
@@ -1,0 +1,5 @@
+---
+"@wdio/visual-service": patch
+---
+
+Fix option "disableBlinkingCursor" to also work within shadowdom

--- a/packages/image-comparison-core/src/clientSideScripts/__snapshots__/setCustomCss.test.ts.snap
+++ b/packages/image-comparison-core/src/clientSideScripts/__snapshots__/setCustomCss.test.ts.snap
@@ -25,7 +25,7 @@ exports[`setCustomCss > should be able to set the custom css with the default op
 
 exports[`setCustomCss > should be able to set the custom css with the with disableBlinkingCursor set to true 1`] = `""`;
 
-exports[`setCustomCss > should be able to set the custom css with the with disableBlinkingCursor set to true 2`] = `" input, textarea, [contenteditable]{caret-color: transparent !important;}"`;
+exports[`setCustomCss > should be able to set the custom css with the with disableBlinkingCursor set to true 2`] = `" *{caret-color: transparent !important;}"`;
 
 exports[`setCustomCss > should be able to set the custom css with the with padding set to 0 1`] = `""`;
 

--- a/packages/image-comparison-core/src/clientSideScripts/setCustomCss.ts
+++ b/packages/image-comparison-core/src/clientSideScripts/setCustomCss.ts
@@ -25,7 +25,7 @@ export default function setCustomCss(cssOptions: CssOptions): void {
     const { addressBarPadding, disableBlinkingCursor, disableCSSAnimation, id, toolBarPadding } = cssOptions
     const bodyTopPadding = addressBarPadding === 0 ? '' : `body{padding-top:${addressBarPadding}px !important}`
     const bodyBottomPadding = toolBarPadding === 0 ? '' : `body{padding-bottom:${toolBarPadding}px !important}`
-    const disableBlinkingCursorCss = disableBlinkingCursor ? ' input, textarea, [contenteditable]{caret-color: transparent !important;}' : ''
+    const disableBlinkingCursorCss = disableBlinkingCursor ? ' *{caret-color: transparent !important;}' : ''
     const css = (disableCSSAnimation ? disableTransformationsTransitionsAnimations : '') +
         bodyTopPadding +
         bodyBottomPadding +


### PR DESCRIPTION
Fixes #1078 

The selector was to specific, and doesn't reach elements inside shadow-dom. With the wildcard selector the caret-color gets inherited.