### PR TITLE
fix: use WdioIcsOptions for wdio-ics:options type augmentation

### DIFF
--- a/.changeset/fix-wdio-ics-options-type.md
+++ b/.changeset/fix-wdio-ics-options-type.md
@@ -1,0 +1,9 @@
+---
+"@wdio/visual-service": patch
+---
+
+Fix incomplete `wdio-ics:options` type augmentation on `WebdriverIO.Capabilities`. The global type declaration now uses the `WdioIcsOptions` interface directly, ensuring all supported properties (`logName`, `name`) are available to TypeScript users in both standalone and multiremote configurations. Fixes #732.
+
+# Committers: 1
+
+- Wim Selles ([@wswebcreation](https://github.com/wswebcreation))

--- a/packages/visual-service/src/index.ts
+++ b/packages/visual-service/src/index.ts
@@ -5,6 +5,7 @@ import type {
     Output,
     Result,
     VisualServiceOptions,
+    WdioIcsOptions,
     WdioCheckFullPageMethodOptions,
     WdioSaveFullPageMethodOptions,
     WdioSaveElementMethodOptions,
@@ -94,9 +95,7 @@ declare global {
         interface MultiRemoteBrowser extends BaseBrowser {}
         interface Element {}
         interface Capabilities {
-            'wdio-ics:options'?:{
-                logName?: string;
-            }
+            'wdio-ics:options'?: WdioIcsOptions;
         }
     }
 

--- a/tests/types/wdio.d.ts
+++ b/tests/types/wdio.d.ts
@@ -4,11 +4,6 @@ declare namespace WebdriverIO {
         chromeBrowserTwo: WebdriverIO.Browser;
     }
     interface Capabilities {
-        // Strange thing is that it's not allowed in the default Capabilities interface
         specs?: string[];
-        'wdio-ics:options'?: {
-            command?: string[];
-            logName?: string;
-        };
     }
 }


### PR DESCRIPTION
## Summary

- Fix incomplete `wdio-ics:options` type augmentation on `WebdriverIO.Capabilities` by using the `WdioIcsOptions` interface instead of an inline type with only `logName`
- This ensures all supported properties (`logName`, `name`) are available to TypeScript users in both standalone and multiremote configurations
- Removed the redundant `wdio-ics:options` workaround from `tests/types/wdio.d.ts` since the proper augmentation now covers it

Fixes #732