### PR TITLE
fix: prevent false emulation detection inside iframe context

### DIFF
--- a/.changeset/fix-iframe-emulation.md
+++ b/.changeset/fix-iframe-emulation.md
@@ -1,0 +1,5 @@
+---
+"@wdio/image-comparison-core": patch
+---
+
+fix: prevent false emulation detection when checkElement is called inside an iframe after switchFrame

--- a/.changeset/fix-iframe-emulation.md
+++ b/.changeset/fix-iframe-emulation.md
@@ -3,3 +3,7 @@
 ---
 
 fix: prevent false emulation detection when checkElement is called inside an iframe after switchFrame
+
+### Committers: 1
+
+-   Taro.Nonoyama([@n2-freevas](https://github.com/n2-freevas))

--- a/.changeset/fix-iframe-emulation.md
+++ b/.changeset/fix-iframe-emulation.md
@@ -1,5 +1,6 @@
 ---
 "@wdio/image-comparison-core": patch
+"@wdio/visual-service": patch
 ---
 
 fix: prevent false emulation detection when checkElement is called inside an iframe after switchFrame

--- a/packages/image-comparison-core/src/clientSideScripts/getScreenDimensions.test.ts
+++ b/packages/image-comparison-core/src/clientSideScripts/getScreenDimensions.test.ts
@@ -168,6 +168,33 @@ describe('getScreenDimensions', () => {
         expect(dimensions.dimensions.window.screenHeight).toBe(1800)
     })
 
+    it('should not detect emulation when running inside an iframe', () => {
+        const originalSelf = window.self
+        Object.defineProperty(window, 'self', {
+            value: {} as Window,
+            configurable: true,
+            writable: true,
+        })
+
+        Object.defineProperty(window, 'devicePixelRatio', { value: 3, configurable: true })
+        Object.defineProperty(window, 'innerWidth', { value: 50, configurable: true })
+        Object.defineProperty(window, 'innerHeight', { value: 100, configurable: true })
+        Object.defineProperty(window, 'matchMedia', {
+            value: vi.fn().mockImplementation(() => ({ matches: false })),
+            ...CONFIGURABLE,
+        })
+
+        const dimensions = getScreenDimensions(false)
+
+        Object.defineProperty(window, 'self', {
+            value: originalSelf,
+            configurable: true,
+            writable: true,
+        })
+
+        expect(dimensions.dimensions.window.isEmulated).toBe(false)
+    })
+
     it('should handle zero devicePixelRatio', () => {
         Object.defineProperty(window, 'devicePixelRatio', { value: 0, configurable: true })
         Object.defineProperty(window, 'innerWidth', { value: 1920, configurable: true })

--- a/packages/image-comparison-core/src/clientSideScripts/getScreenDimensions.ts
+++ b/packages/image-comparison-core/src/clientSideScripts/getScreenDimensions.ts
@@ -10,8 +10,10 @@ export default function getScreenDimensions(isMobile: boolean): ScreenDimensions
     const dpr = window.devicePixelRatio || 1
     const minEdge = Math.min(width, height)
     const maxEdge = Math.max(width, height)
+    const isInIframe = window.self !== window.top
     const isLikelyEmulated =
         !isMobile &&              // Only check for emulated on desktop
+        !isInIframe &&            // Skip emulation detection inside iframes
         dpr >= 2 &&               // High-DPI signal
         minEdge <= 800 &&         // Catch phones/tablets in portrait/landscape
         maxEdge <= 1280 &&        // Conservative max for emulated tablet sizes


### PR DESCRIPTION
for : https://github.com/webdriverio/visual-testing/issues/1156