### PR TITLE
docs: document ignore* options for pixelmatch engine

### DIFF
--- a/.changeset/docs-ignore-options-pixelmatch.md
+++ b/.changeset/docs-ignore-options-pixelmatch.md
@@ -1,0 +1,20 @@
+---
+"@wdio/image-comparison-core": patch
+"@wdio/visual-service": patch
+---
+
+docs: document ignore* options for pixelmatch engine
+
+**What changed**
+
+- JSDoc on each `ignore*` option in `base.interfaces.ts` and `options.interfaces.ts` with pixelmatch preset mapping
+- README section: comparison table, last-wins semantics, default vs resemble v9
+- Removed redundant `ignoreAntialiasing: true` from Sauce/Lambda e2e configs (matches v10 default)
+
+**Migration**
+
+- Documentation only; no behaviour change
+
+### Committers: 1
+
+- Wim Selles ([@wswebcreation](https://github.com/wswebcreation))

--- a/packages/image-comparison-core/README.md
+++ b/packages/image-comparison-core/README.md
@@ -10,3 +10,40 @@ npm install @wdio/image-comparison-core --save-dev
 ```
 
 Instructions on how to get started can be found in the [visual testing](https://webdriver.io/docs/visual-testing) docs on the WebdriverIO project page.
+
+## `ignore*` comparison options (pixelmatch)
+
+v10 uses [pixelmatch](https://github.com/mapbox/pixelmatch) instead of resemble.js. The public `ignore*` API is preserved and mapped to resemble-style presets via last-wins semantics.
+
+### Defaults vs resemble v9
+
+| | v9 (resemble.js) | v10 default |
+|---|---|---|
+| AA forgiveness | opt-in (`ignoreAntialiasing: true`) | on by default (`ignoreAntialiasing: true`) |
+| Strict comparison | default | set `ignoreAntialiasing: false` |
+| Engine | resemble RGB/brightness | pixelmatch YIQ perceptual distance |
+
+No config change is needed if you rely on forgiving comparison behaviour.
+
+### Preset mapping
+
+| Option | Preprocessing | pixelmatch threshold | AA forgiven |
+|---|---|---|---|
+| *(none, `ignoreAntialiasing: false`)* | — | ~16/255 (`0.063`) | no |
+| `ignoreAntialiasing` | — | ~32/255 (`0.13`) | yes |
+| `ignoreLess` | — | ~16/255 (`0.063`) | no |
+| `ignoreAlpha` | alpha → opaque | ~16/255 (`0.063`) | no |
+| `ignoreColors` | resemble luma grayscale | ~16/255 (`0.063`) | no |
+| `ignoreNothing` | — | `0` | no |
+
+Thresholds are calibrated to resemble outcomes; the underlying algorithm is YIQ perceptual distance, not resemble's RGB math.
+
+### Last-wins semantics
+
+When multiple `ignore*` flags are enabled, the active preset is the **last** one in this order (matching resemble.js):
+
+`alpha` → `antialiasing` → `colors` → `less` → `nothing`
+
+Example: `ignoreLess: true` with the default `ignoreAntialiasing: true` resolves to the `ignoreLess` preset — strict AA, not forgiving.
+
+Golden fixture tests documenting expected pass/fail behaviour live in [`tests/fixtures/ignore-options/`](./tests/fixtures/ignore-options/).

--- a/packages/image-comparison-core/src/base.interfaces.ts
+++ b/packages/image-comparison-core/src/base.interfaces.ts
@@ -90,27 +90,36 @@ export interface BaseMobileWebScreenshotOptions {
 
 export interface BaseImageCompareOptions {
     /**
-     * Compare images and discard alpha
+     * Ignore alpha-channel differences during comparison.
+     * Preprocessing sets all alpha values to opaque before pixelmatch runs.
+     * Preset: strict threshold (~16/255), AA not forgiven.
      * @default false
      */
     ignoreAlpha?: boolean;
     /**
-     * Compare images and forgive anti-aliasing differences
+     * Forgive anti-aliased pixels during comparison (pixelmatch `includeAA: false`).
+     * Preset: relaxed threshold (~32/255), AA forgiven.
+     * When combined with other ignore flags, last-wins order applies
+     * (`alpha` → `antialiasing` → `colors` → `less` → `nothing`).
      * @default true
      */
     ignoreAntialiasing?: boolean;
     /**
-     * Compare images in black and white mode
+     * Compare brightness only, ignoring hue differences.
+     * Preprocessing converts both images to grayscale using resemble luma (`0.3/0.59/0.11`).
+     * Preset: strict threshold (~16/255), AA not forgiven.
      * @default false
      */
     ignoreColors?: boolean;
     /**
-     * Compare with reduced color sensitivity
+     * Use a relaxed RGB tolerance (~16/255 per channel in YIQ space).
+     * Preset: strict threshold, AA not forgiven (does not inherit default AA forgiveness).
      * @default false
      */
     ignoreLess?: boolean;
     /**
-     * Compare with maximum sensitivity
+     * Use zero tolerance — any pixel difference counts as a mismatch.
+     * Preset: threshold `0`, AA not forgiven.
      * @default false
      */
     ignoreNothing?: boolean;

--- a/packages/image-comparison-core/src/helpers/options.interfaces.ts
+++ b/packages/image-comparison-core/src/helpers/options.interfaces.ts
@@ -159,31 +159,38 @@ export interface ClassOptions {
     diffPixelBoundingBoxProximity?: number;
 
     /**
-     * Ignore alpha channel when comparing images.
+     * Ignore alpha-channel differences during comparison.
+     * Preprocessing sets all alpha values to opaque before pixelmatch runs.
+     * Preset: strict threshold (~16/255), AA not forgiven.
      */
     ignoreAlpha?: boolean;
 
     /**
-     * Forgive anti-aliasing differences when comparing images.
+     * Forgive anti-aliased pixels during comparison (pixelmatch `includeAA: false`).
+     * Preset: relaxed threshold (~32/255), AA forgiven.
+     * When combined with other ignore flags, last-wins order applies
+     * (`alpha` → `antialiasing` → `colors` → `less` → `nothing`).
      * Defaults to `true` so sub-pixel rendering noise is ignored out of the box.
-     * Set to `false` for strict pixel comparison where AA pixels count as mismatches.
+     * Set to `false` for strict comparison where AA pixels count as mismatches.
      */
     ignoreAntialiasing?: boolean;
 
     /**
-     * Compare two images in black and white only.
+     * Compare brightness only, ignoring hue differences.
+     * Preprocessing converts both images to grayscale using resemble luma (`0.3/0.59/0.11`).
+     * Preset: strict threshold (~16/255), AA not forgiven.
      */
     ignoreColors?: boolean;
 
     /**
-     * Compare images with reduced sensitivity.
-     * red = 16, green = 16, blue = 16, alpha = 16, minBrightness = 16, maxBrightness = 240
+     * Use a relaxed RGB tolerance (~16/255 per channel in YIQ space).
+     * Preset: strict threshold, AA not forgiven (does not inherit default AA forgiveness).
      */
     ignoreLess?: boolean;
 
     /**
-     * Compare images with full sensitivity.
-     * red = 0, green = 0, blue = 0, alpha = 0, minBrightness = 0, maxBrightness = 255
+     * Use zero tolerance — any pixel difference counts as a mismatch.
+     * Preset: threshold `0`, AA not forgiven.
      */
     ignoreNothing?: boolean;
 
@@ -437,29 +444,36 @@ export interface CompareOptions {
     diffPixelBoundingBoxProximity: number;
 
     /**
-     * Compare images and discard the alpha channel.
+     * Ignore alpha-channel differences during comparison.
+     * Preprocessing sets all alpha values to opaque before pixelmatch runs.
+     * Preset: strict threshold (~16/255), AA not forgiven.
      */
     ignoreAlpha: boolean;
 
     /**
-     * Forgive anti-aliasing differences when comparing images.
+     * Forgive anti-aliased pixels during comparison (pixelmatch `includeAA: false`).
+     * Preset: relaxed threshold (~32/255), AA forgiven.
+     * When combined with other ignore flags, last-wins order applies
+     * (`alpha` → `antialiasing` → `colors` → `less` → `nothing`).
      */
     ignoreAntialiasing: boolean;
 
     /**
-     * Compare two black-and-white versions of the images, ignoring colors.
+     * Compare brightness only, ignoring hue differences.
+     * Preprocessing converts both images to grayscale using resemble luma (`0.3/0.59/0.11`).
+     * Preset: strict threshold (~16/255), AA not forgiven.
      */
     ignoreColors: boolean;
 
     /**
-     * Use a less sensitive comparison setting:
-     * red = 16, green = 16, blue = 16, alpha = 16, minBrightness = 16, maxBrightness = 240
+     * Use a relaxed RGB tolerance (~16/255 per channel in YIQ space).
+     * Preset: strict threshold, AA not forgiven (does not inherit default AA forgiveness).
      */
     ignoreLess: boolean;
 
     /**
-     * Use the most sensitive comparison setting:
-     * red = 0, green = 0, blue = 0, alpha = 0, minBrightness = 0, maxBrightness = 255
+     * Use zero tolerance — any pixel difference counts as a mismatch.
+     * Preset: threshold `0`, AA not forgiven.
      */
     ignoreNothing: boolean;
 

--- a/tests/configs/wdio.lambdatest.shared.conf.ts
+++ b/tests/configs/wdio.lambdatest.shared.conf.ts
@@ -44,7 +44,6 @@ export const config: WebdriverIO.Config  = {
                 blockOutSideBar: true,
                 createJsonReportFiles: false,
                 rawMisMatchPercentage: !!process.env.RAW_MISMATCH || false,
-                ignoreAntialiasing: true,
                 alwaysSaveActualImage: false,
             } satisfies VisualServiceOptions,
         ],

--- a/tests/configs/wdio.saucelabs.shared.conf.ts
+++ b/tests/configs/wdio.saucelabs.shared.conf.ts
@@ -49,7 +49,6 @@ export const config: WebdriverIO.Config  = {
                 createJsonReportFiles: true,
                 rawMisMatchPercentage: !!process.env.RAW_MISMATCH || false,
                 enableLayoutTesting: true,
-                ignoreAntialiasing: true,
             } satisfies VisualServiceOptions,
         ],
     ],


### PR DESCRIPTION
- add JSDoc preset mapping on each ignore* option
- add README section with comparison table and last-wins semantics
- remove redundant ignoreAntialiasing from Sauce/Lambda configs
- add patch changeset